### PR TITLE
Remove bsdtar usage

### DIFF
--- a/.changeset/stupid-nails-happen.md
+++ b/.changeset/stupid-nails-happen.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+stop using bsdtar

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -203,13 +203,7 @@ Update your application Dockerfile using one of the templates at https://github.
             "crane",
             "export",
             "-", // OCI Image from stdin
-            "-", // rootfs tarball to stdout
-            "|",
-            "bsdtar",
-            "-cf",
-            "/tmp/output",
-            "--format=gnutar",
-            "@/dev/stdin", // rootfs tarball from stdin
+            "/tmp/output", // rootfs tarball
         ];
         return ["/usr/bin/env", "bash", "-c", cmd.join(" ")];
     }


### PR DESCRIPTION
This PR will remove the dependency on `bsdtar`.

Depends: #13

Testing this using cartesi/sdk:0.6.0 I get:

```
$ cartesi build
...
archive_read_next_header(): Linkname can't be converted from UTF-8 to current locale
```

Using `cartesi/sdk:0.6.1` and removing the usage of bsdtar tool, it builds OK.