### PR TITLE
feat(cli): use cartesi as compose project name

### DIFF
--- a/.changeset/wild-gorillas-decide.md
+++ b/.changeset/wild-gorillas-decide.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+use cartesi as compose project name

--- a/apps/cli/src/node/docker-compose-cartesi.yaml
+++ b/apps/cli/src/node/docker-compose-cartesi.yaml
@@ -1,0 +1,1 @@
+name: cartesi


### PR DESCRIPTION
This PT will make the docker compose use `cartesi` as project name.

This way, instead of having a random string as the prefix for containers we'll have `cartesi` as prefix.

This will make it easier for us to grab logs or execute commands on a specific container, like:

```shell
docker logs -f cartesi-validator-1
docker exec -ti cartesi-validator-1 ls -lha /
```