### PR TITLE
SDK with ERC-4337 contracts and alto

### DIFF
--- a/.changeset/hot-spiders-cover.md
+++ b/.changeset/hot-spiders-cover.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+add alto bundler

--- a/.changeset/short-oranges-happen.md
+++ b/.changeset/short-oranges-happen.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+bump devnet version to include ERC-4337 smart contracts

--- a/.changeset/young-cycles-add.md
+++ b/.changeset/young-cycles-add.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+new anvil version with correct dumpState

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -47,6 +47,11 @@ curl -sSL https://github.com/google/go-containerregistry/releases/download/v${CR
     tar -zx -C /usr/local/bin
 EOF
 
+# alto
+FROM node:18.19.0-bookworm AS alto
+ARG ALTO_VERSION
+RUN npm install -g @pimlico/alto@${ALTO_VERSION}
+
 # devnet files
 FROM node:slim as devnet
 ARG DEVNET_VERSION
@@ -72,6 +77,7 @@ apt-get install -y --no-install-recommends \
     jq \
     libarchive-tools \
     locales \
+    nodejs \
     squashfs-tools \
     xxd \
     xz-utils
@@ -102,6 +108,7 @@ RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${
     tar -zx -C /usr/local/bin
 
 # healthcheck script using net_listening JSON-RPC method
+COPY alto /usr/local/bin
 COPY devnet /usr/local/bin
 COPY eth_isready /usr/local/bin
 COPY eth_dump /usr/local/bin
@@ -109,6 +116,7 @@ COPY eth_load /usr/local/bin
 COPY create_machine_snapshot /usr/local/bin
 
 COPY entrypoint.sh /usr/local/bin/
+COPY --from=alto /usr/local/lib/node_modules/@pimlico/alto /usr/local/lib/node_modules/@pimlico/alto
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 COPY --from=crane /usr/local/bin/crane /usr/local/bin/
 COPY --from=devnet /usr/local/lib/node_modules/@cartesi/devnet/export/abi/localhost.json /usr/share/cartesi/

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -97,7 +97,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # download anvil pre-compiled binaries
-ARG ANVIL_VERSION=8b694bbcabaedffc0337bf8dea9a135da5694ef9
+ARG ANVIL_VERSION=e90348416c3a831ab75bb43f6fa5f0a0be4106c4
 RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${ANVIL_VERSION}/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
     tar -zx -C /usr/local/bin
 

--- a/packages/sdk/alto
+++ b/packages/sdk/alto
@@ -1,0 +1,2 @@
+#!/bin/sh
+node "/usr/local/lib/node_modules/@pimlico/alto/esm/cli/index.js" $@

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -9,6 +9,7 @@ target "default" {
     SERVER_MANAGER_ORG            = "cartesi"
     SERVER_MANAGER_VERSION        = "0.9.1"
     CARTESI_IMAGE_KERNEL_VERSION  = "0.19.1"
+    ALTO_VERSION                  = "0.0.4"
     DEVNET_VERSION                = "1.8.0"
     LINUX_KERNEL_VERSION          = "6.5.9-ctsi-1-v0.19.1"
     XGENEXT2_VERSION              = "1.5.6"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -9,7 +9,7 @@ target "default" {
     SERVER_MANAGER_ORG            = "cartesi"
     SERVER_MANAGER_VERSION        = "0.9.1"
     CARTESI_IMAGE_KERNEL_VERSION  = "0.19.1"
-    DEVNET_VERSION                = "1.7.0"
+    DEVNET_VERSION                = "1.8.0"
     LINUX_KERNEL_VERSION          = "6.5.9-ctsi-1-v0.19.1"
     XGENEXT2_VERSION              = "1.5.6"
   }


### PR DESCRIPTION
- update anvil to the latest nightly with a fix of dumpState
- bump devnet to include ERC-4337 anvil state
- Adds [alto](https://github.com/pimlicolabs/alto), a javascript bundler by pimlico to the SDK

To test:

```
pnpm i
pnpm run build
```

```
docker run cartesi/sdk:devel anvil --version
anvil 0.2.0 (e903484 2024-07-19T00:38:57.930267239Z)

docker run -e ANVIL_IP_ADDR=0.0.0.0 -p 8545:8545 cartesi/sdk:devel devnet
cast code 0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419

docker run cartesi/sdk:devel alto --help
```
