### PR TITLE
Bump SDK to 0.9.0

### DIFF
--- a/.changeset/good-kiwis-dance.md
+++ b/.changeset/good-kiwis-dance.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": minor
+---
+
+bump sdk to 0.9.0 (new anvil version)

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -30,7 +30,7 @@ const CARTESI_DEFAULT_RAM_SIZE = "128Mi";
 
 const CARTESI_LABEL_SDK_VERSION = `${CARTESI_LABEL_PREFIX}.sdk_version`;
 const CARTESI_LABEL_SDK_NAME = `${CARTESI_LABEL_PREFIX}.sdk_name`;
-const CARTESI_DEFAULT_SDK_VERSION = "0.6.2";
+const CARTESI_DEFAULT_SDK_VERSION = "0.9.0";
 
 export default class BuildApplication extends BaseCommand<
     typeof BuildApplication

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -33,7 +33,7 @@ export default class Shell extends BaseCommand<typeof Shell> {
         const ext2 = path.join(containerDir, path.basename(ext2Path));
         const ramSize = "128Mi";
         const driveLabel = "root";
-        const sdkImage = "cartesi/sdk:0.6.0"; // XXX: how to resolve sdk version?
+        const sdkImage = "cartesi/sdk:0.9.0"; // XXX: how to resolve sdk version?
         const args = [
             "run",
             "--interactive",

--- a/apps/cli/src/node/docker-compose-anvil.yaml
+++ b/apps/cli/src/node/docker-compose-anvil.yaml
@@ -1,6 +1,6 @@
 services:
     anvil:
-        image: cartesi/sdk:0.6.0
+        image: cartesi/sdk:0.9.0
         command:
             [
                 "devnet",
@@ -19,7 +19,7 @@ services:
             - 8545:8545
 
     dapp_deployer:
-        image: cartesi/sdk:0.6.0
+        image: cartesi/sdk:0.9.0
         restart: on-failure
         depends_on:
             anvil:


### PR DESCRIPTION
Bump SDK to 0.9.0, which includes new anvil version
There are also part of ERC-4337 infrastructure, but not complete yet
