### PR TITLE
Add paymaster to SDK

### DIFF
--- a/.changeset/lemon-rivers-cover.md
+++ b/.changeset/lemon-rivers-cover.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+add paymaster to SDK

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -65,6 +65,7 @@ ARG SERVER_MANAGER_VERSION
 ARG CARTESI_IMAGE_KERNEL_VERSION
 ARG LINUX_KERNEL_VERSION
 ARG XGENEXT2_VERSION
+ARG PAYMASTER_VERSION
 
 USER root
 ARG DEBIAN_FRONTEND=noninteractive
@@ -78,6 +79,7 @@ apt-get install -y --no-install-recommends \
     libarchive-tools \
     locales \
     nodejs \
+    npm \
     squashfs-tools \
     xxd \
     xz-utils
@@ -96,6 +98,11 @@ curl -sSL https://github.com/cartesi/genext2fs/releases/download/v${XGENEXT2_VER
 dpkg -i ./xgenext2fs.deb
 rm ./xgenext2fs.deb
 xgenext2fs --version
+EOF
+
+# Install mock-verifying-paymaster
+RUN <<EOF
+npm install -g @cartesi/mock-verifying-paymaster@${PAYMASTER_VERSION}
 EOF
 
 ENV LC_ALL en_US.UTF-8

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -10,6 +10,7 @@ target "default" {
     SERVER_MANAGER_VERSION        = "0.9.1"
     CARTESI_IMAGE_KERNEL_VERSION  = "0.19.1"
     ALTO_VERSION                  = "0.0.4"
+    PAYMASTER_VERSION             = "0.2.0"
     DEVNET_VERSION                = "1.8.0"
     LINUX_KERNEL_VERSION          = "6.5.9-ctsi-1-v0.19.1"
     XGENEXT2_VERSION              = "1.5.6"


### PR DESCRIPTION
This adds the mock-verifying-paymaster to the SDK

To test:

```
pnpm run build
docker run cartesi/sdk:devel mock-verifying-paymaster
```

You should see an error of missing env vars:

```
 No URL was provided to the Transport. Please provide a valid RPC URL to the Transport
```

But that means it's working.
A future PR will add the services to docker compose.
