### PR TITLE
fix(cli): ignore .env file for cartesi run

### DIFF
--- a/.changeset/short-hairs-tease.md
+++ b/.changeset/short-hairs-tease.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+ignore .env file when using cartesi run

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -192,6 +192,14 @@ export default class Run extends BaseCommand<typeof Run> {
         process.on("SIGINT", () => {});
 
         try {
+            // mask .env
+            if (fs.existsSync("./.env")) {
+                this.warn(
+                    "Ignoring .env file. You should create a .cartesi.env if you want to set environment variables for the rollups-node.",
+                );
+                await fs.rename(".env", ".masked.env");
+            }
+
             if (flags["dry-run"]) {
                 // show the docker compose configuration
                 await execa("docker", [...compose_args, "config"], {
@@ -217,6 +225,10 @@ export default class Run extends BaseCommand<typeof Run> {
                 env,
                 stdio: "inherit",
             });
+            // unmask .env
+            if (fs.existsSync("./.masked.env")) {
+                await fs.rename(".masked.env", ".env");
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #60 

I don't particularly appreciate messing up with files not in the cli context, but that's what I have for now.