### PR TITLE
feat(cli): expose rollups-node prometheus metrics

### DIFF
--- a/.changeset/silent-bags-accept.md
+++ b/.changeset/silent-bags-accept.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+expose rollups-node prometheus metrics

--- a/apps/cli/src/node/docker-compose-validator.yaml
+++ b/apps/cli/src/node/docker-compose-validator.yaml
@@ -32,6 +32,7 @@ services:
         environment:
             PROMPT_TXT_02_GRAPHQL: "GraphQL running at http://localhost:${CARTESI_LISTEN_PORT}/graphql"
             PROMPT_TXT_03_INSPECT: "Inspect running at http://localhost:${CARTESI_LISTEN_PORT}/inspect/"
+            PROMPT_TXT_08_METRICS: "Prometheus metrics at http://localhost:${CARTESI_LISTEN_PORT}/metrics"
 
     traefik-config-generator:
         environment:
@@ -57,3 +58,14 @@ services:
                             loadBalancer:
                                 servers:
                                     - url: "http://validator:10000/graphql"
+            TRAEFIK_CONFIG_VALIDATOR_METRICS: |
+                http:
+                    routers:
+                        validator_metrics:
+                            rule: "PathPrefix(`/metrics`)"
+                            service: validator_metrics
+                    services:
+                        validator_metrics:
+                            loadBalancer:
+                                servers:
+                                    - url: "http://validator:10000/metrics"


### PR DESCRIPTION
This PR will export rollups-node (validator) metrics at `http://localhost:8080/metrics`.

```shell
> cartesi run
Attaching to prompt-1, validator-1
(...)
prompt-1     | Prometheus metrics at http://localhost:8080/metrics
prompt-1     | Press Ctrl+C to stop the node
```