### PR TITLE
Add cpu and mem limits options

### DIFF
--- a/.changeset/chatty-toes-relate.md
+++ b/.changeset/chatty-toes-relate.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+adds --dry-run to run command

--- a/.changeset/tidy-dolphins-serve.md
+++ b/.changeset/tidy-dolphins-serve.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+add --cpus and --memory to run command

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -54,6 +54,16 @@ export default class Run extends BaseCommand<typeof Run> {
             description: "port to listen for incoming connections",
             default: 8080,
         }),
+        cpus: Flags.integer({
+            description:
+                "Define the number of CPUs to use (eg.: 1) for the rollups-node",
+            summary: "number of cpu limits for the rollups-node",
+        }),
+        memory: Flags.integer({
+            description:
+                "Define the amount of memory to use for the rollups-node in MB (eg.: 1024)",
+            summary: "memory limit for the rollups-node in MB",
+        }),
         "dry-run": Flags.boolean({
             description: "show the docker compose configuration",
             default: false,
@@ -104,10 +114,18 @@ export default class Run extends BaseCommand<typeof Run> {
             CARTESI_SNAPSHOT_DIR: "/usr/share/rollups-node/snapshot",
             CARTESI_BIN_PATH: binPath,
             CARTESI_LISTEN_PORT: listenPort.toString(),
+            CARTESI_VALIDATOR_CPUS: flags.cpus?.toString(),
+            CARTESI_VALIDATOR_MEMORY: flags.memory?.toString(),
         };
 
         // validator
         const composeFiles = ["docker-compose-validator.yaml"];
+        if (flags.cpus) {
+            composeFiles.push("docker-compose-validator-cpus.yaml");
+        }
+        if (flags.memory) {
+            composeFiles.push("docker-compose-validator-memory.yaml");
+        }
 
         // prompt
         composeFiles.push("docker-compose-prompt.yaml");

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -54,6 +54,11 @@ export default class Run extends BaseCommand<typeof Run> {
             description: "port to listen for incoming connections",
             default: 8080,
         }),
+        "dry-run": Flags.boolean({
+            description: "show the docker compose configuration",
+            default: false,
+            hidden: true,
+        }),
     };
 
     public async run(): Promise<void> {
@@ -169,6 +174,15 @@ export default class Run extends BaseCommand<typeof Run> {
         process.on("SIGINT", () => {});
 
         try {
+            if (flags["dry-run"]) {
+                // show the docker compose configuration
+                await execa("docker", [...compose_args, "config"], {
+                    env,
+                    stdio: "inherit",
+                });
+                return;
+            }
+
             // run compose environment
             await execa("docker", [...compose_args, "up", ...up_args], {
                 env,

--- a/apps/cli/src/node/docker-compose-validator-cpus.yaml
+++ b/apps/cli/src/node/docker-compose-validator-cpus.yaml
@@ -1,0 +1,6 @@
+services:
+    validator:
+        deploy:
+            resources:
+                limits:
+                    cpus: "${CARTESI_VALIDATOR_CPUS}"

--- a/apps/cli/src/node/docker-compose-validator-memory.yaml
+++ b/apps/cli/src/node/docker-compose-validator-memory.yaml
@@ -1,0 +1,6 @@
+services:
+    validator:
+        deploy:
+            resources:
+                limits:
+                    memory: "${CARTESI_VALIDATOR_MEMORY}M"


### PR DESCRIPTION
This PR will add `--cpus` and `--memory` options for `cartesi run` command. This way it will be possible to define these in alignment with the production deployment values and evaluate locally if those values are enough for the application to run smoothly.

Also, it was added a hidden `--dry-run` to the run command, that will show the .yaml compose file in case it's needed to debug the compose file.