### PR TITLE
cli: enforce build for linux/riscv64 platform

### DIFF
--- a/.changeset/big-ghosts-rescue.md
+++ b/.changeset/big-ghosts-rescue.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+enforce build for linux/riscv64 platform

--- a/apps/cli/src/builder/docker.ts
+++ b/apps/cli/src/builder/docker.ts
@@ -26,6 +26,8 @@ const buildImage = async (options: ImageBuildOptions): Promise<string> => {
     const args = [
         "buildx",
         "build",
+        "--platform",
+        "linux/riscv64",
         "--file",
         dockerfile,
         "--load",

--- a/apps/cli/src/builder/docker.ts
+++ b/apps/cli/src/builder/docker.ts
@@ -53,6 +53,9 @@ const buildImage = async (options: ImageBuildOptions): Promise<string> => {
  * @returns Information about the image
  */
 const getImageInfo = async (image: string): Promise<ImageInfo> => {
+    // pull image to ensure it is available
+    await execa("docker", ["image", "pull", image]);
+
     const { stdout: jsonStr } = await execa("docker", [
         "image",
         "inspect",

--- a/apps/cli/src/builder/docker.ts
+++ b/apps/cli/src/builder/docker.ts
@@ -53,9 +53,6 @@ const buildImage = async (options: ImageBuildOptions): Promise<string> => {
  * @returns Information about the image
  */
 const getImageInfo = async (image: string): Promise<ImageInfo> => {
-    // pull image to ensure it is available
-    await execa("docker", ["image", "pull", image]);
-
     const { stdout: jsonStr } = await execa("docker", [
         "image",
         "inspect",
@@ -94,7 +91,13 @@ export const build = async (
     const filename = `${name}.${format}`;
 
     // use pre-existing image or build docker image
-    const image = drive.image || (await buildImage(drive));
+    let image: string;
+    if (drive.image) {
+        image = drive.image;
+        await execa("docker", ["image", "pull", image]);
+    } else {
+        image = await buildImage(drive);
+    }
 
     // get image info
     const imageInfo = await getImageInfo(image);

--- a/apps/cli/test/builder/data/Dockerfile.nonriscv
+++ b/apps/cli/test/builder/data/Dockerfile.nonriscv
@@ -1,2 +1,0 @@
-FROM scratch
-ADD ./file1 .

--- a/apps/cli/test/builder/docker.test.ts
+++ b/apps/cli/test/builder/docker.test.ts
@@ -35,11 +35,10 @@ describe("when building with the docker builder", () => {
         const drive: DockerDriveConfig = {
             builder: "docker",
             context: path.join(__dirname, "data"),
-            dockerfile: path.join(__dirname, "data", "Dockerfile.nonriscv"),
             extraSize: 0,
             format: "ext2",
             tags: [],
-            image: undefined,
+            image: "debian:bookworm-slim",
             target: undefined,
         };
         await expect(build("root", drive, image, destination)).rejects.toThrow(


### PR DESCRIPTION
Since the target is always a Cartesi Machine (riscv64), cartesi build should enforce the docker build environment via `--platform` argument.

This way `Dockerfile` from cartesi/application-templates should be something like this.

**javascript**

```Dockerfile
#BUILDER
FROM --platform=$BUILDPLATFORM node:20.16.0-bookworm AS build-stage
(...)

#TARGET
FROM cartesi/node:20.16.0-jammy-slim
(...)
```

We should only need to define `--platform` when we want to run something on the host platform, for a cross-compilation or build stage that could be faster without the linux/riscv64 qemu of the docker builder.

The example above uses the `$BUILDPLATFORM`, which is recommended so it will use the host platform.

The second and last `FROM` doesn't need a `--platform` since this will be enforced by the `cartesi build`.