### PR TITLE
Add optional espresso-dev-node to `cartesi run`

### DIFF
--- a/.changeset/fresh-mangos-wink.md
+++ b/.changeset/fresh-mangos-wink.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": minor
+---
+
+add `--enable-espresso` to `cartesi run`

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -35,6 +35,11 @@ export default class Run extends BaseCommand<typeof Run> {
                 "disable local paymaster service to save machine resources",
             summary: "disable paymaster service",
         }),
+        "enable-espresso": Flags.boolean({
+            default: false,
+            description: "enable Espresso development node ",
+            summary: "enable Espresso development node",
+        }),
         "epoch-length": Flags.integer({
             description: "length of an epoch (in blocks)",
             default: 720,
@@ -151,6 +156,11 @@ export default class Run extends BaseCommand<typeof Run> {
         if (!flags["disable-paymaster"] && !flags["disable-bundler"]) {
             // only add paymaster if bundler is enabled
             composeFiles.push("docker-compose-paymaster.yaml");
+        }
+
+        // espresso development node
+        if (flags["enable-espresso"]) {
+            composeFiles.push("docker-compose-espresso.yaml");
         }
 
         // load the no-backend compose file

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -74,7 +74,7 @@ export class InvalidStringArrayError extends Error {
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
 const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
-export const DEFAULT_SDK = "cartesi/sdk:0.12.0-alpha.1";
+export const DEFAULT_SDK = "cartesi/sdk:0.12.0-alpha.3";
 
 type Builder = "directory" | "docker" | "empty" | "none" | "tar";
 type DriveFormat = "ext2" | "sqfs";

--- a/apps/cli/src/node/docker-compose-anvil.yaml
+++ b/apps/cli/src/node/docker-compose-anvil.yaml
@@ -1,6 +1,6 @@
 services:
     anvil:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         command:
             [
                 "devnet",
@@ -19,7 +19,7 @@ services:
             - 8545:8545
 
     dapp_deployer:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         restart: on-failure
         depends_on:
             anvil:

--- a/apps/cli/src/node/docker-compose-bundler.yaml
+++ b/apps/cli/src/node/docker-compose-bundler.yaml
@@ -1,6 +1,6 @@
 services:
     alto:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         command:
             - "alto"
             - "--entrypoints"

--- a/apps/cli/src/node/docker-compose-database.yaml
+++ b/apps/cli/src/node/docker-compose-database.yaml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
             interval: 10s

--- a/apps/cli/src/node/docker-compose-espresso.yaml
+++ b/apps/cli/src/node/docker-compose-espresso.yaml
@@ -1,0 +1,124 @@
+services:
+    espresso_database_creator:
+        image: postgres:16-alpine
+        command: ["createdb", "sequencer"]
+        depends_on:
+            database:
+                condition: service_healthy
+        environment:
+            PGHOST: ${PGHOST:-database}
+            PGPORT: ${PGPORT:-5432}
+            PGUSER: ${PGUSER:-postgres}
+            PGPASSWORD: ${PGPASSWORD:-password}
+            PGDATABASE: ${PGDATABASE:-postgres}
+
+    espresso:
+        image: cartesi/sdk:0.12.0-alpha.3
+        command: ["/usr/local/bin/espresso-dev-node"]
+        deploy:
+            resources:
+                limits:
+                    cpus: "4"
+                    memory: "1G"
+        ports:
+            - 8770:8770
+            - 8771:8771
+            - 8772:8772
+            - 20000:20000
+        depends_on:
+            espresso_database_creator:
+                condition: service_completed_successfully
+            database:
+                condition: service_healthy
+        environment:
+            ESPRESSO_SEQUENCER_L1_PROVIDER: ${CARTESI_BLOCKCHAIN_HTTP_ENDPOINT:-http://anvil:8545}
+            ESPRESSO_SEQUENCER_API_PORT: 8770
+            ESPRESSO_BUILDER_PORT: 8771
+            ESPRESSO_PROVER_PORT: 8772
+            ESPRESSO_DEV_NODE_PORT: 20000
+            ESPRESSO_SEQUENCER_POSTGRES_HOST: database
+            ESPRESSO_SEQUENCER_POSTGRES_PORT: 5432
+            ESPRESSO_SEQUENCER_POSTGRES_USER: postgres
+            ESPRESSO_SEQUENCER_POSTGRES_PASSWORD: password
+            ESPRESSO_SEQUENCER_POSTGRES_DATABASE: sequencer
+            ESPRESSO_SEQUENCER_ETH_MNEMONIC: ${CARTESI_AUTH_MNEMONIC:-test test test test test test test test test test test junk}
+
+    prompt:
+        image: debian:bookworm-slim
+        environment:
+            PROMPT_TXT_07_ESPRESSO: "Espresso running at http://localhost:${CARTESI_LISTEN_PORT}/espresso/"
+
+    traefik-config-generator:
+        environment:
+            TRAEFIK_CONFIG_ESPRESSO_DEV: |
+                http:
+                    routers:
+                        espresso-dev:
+                            rule: "PathPrefix(`/espresso/dev`)"
+                            middlewares:
+                                - "remove-espresso-dev-prefix"
+                            service: espresso-dev
+                    middlewares:
+                        remove-espresso-dev-prefix:
+                            replacePathRegex:
+                                regex: "^/espresso/dev/(.*)"
+                                replacement: "/$1"
+                    services:
+                        espresso-dev:
+                            loadBalancer:
+                                servers:
+                                    - url: "http://espresso:20000"
+            TRAEFIK_CONFIG_ESPRESSO_SEQUENCER: |
+                http:
+                    routers:
+                        espresso-sequencer:
+                            rule: "PathPrefix(`/espresso/sequencer`)"
+                            middlewares:
+                                - "remove-espresso-sequencer-prefix"
+                            service: espresso-sequencer
+                    middlewares:
+                        remove-espresso-sequencer-prefix:
+                            replacePathRegex:
+                                regex: "^/espresso/sequencer/(.*)"
+                                replacement: "/$1"
+                    services:
+                        espresso-sequencer:
+                            loadBalancer:
+                                servers:
+                                    - url: "http://espresso:8770"
+            TRAEFIK_CONFIG_ESPRESSO_BUILDER: |
+                http:
+                    routers:
+                        espresso-builder:
+                            rule: "PathPrefix(`/espresso/builder`)"
+                            middlewares:
+                                - "remove-espresso-builder-prefix"
+                            service: espresso-builder
+                    middlewares:
+                        remove-espresso-builder-prefix:
+                            replacePathRegex:
+                                regex: "^/espresso/builder/(.*)"
+                                replacement: "/$1"
+                    services:
+                        espresso-builder:
+                            loadBalancer:
+                                servers:
+                                    - url: "http://espresso:8771"
+            TRAEFIK_CONFIG_ESPRESSO_PROVER: |
+                http:
+                    routers:
+                        espresso-prover:
+                            rule: "PathPrefix(`/espresso/prover`)"
+                            middlewares:
+                                - "remove-espresso-prover-prefix"
+                            service: espresso-prover
+                    middlewares:
+                        remove-espresso-prover-prefix:
+                            replacePathRegex:
+                                regex: "^/espresso/prover/(.*)"
+                                replacement: "/$1"
+                    services:
+                        espresso-prover:
+                            loadBalancer:
+                                servers:
+                                    - url: "http://espresso:8772"

--- a/apps/cli/src/node/docker-compose-explorer.yaml
+++ b/apps/cli/src/node/docker-compose-explorer.yaml
@@ -1,6 +1,6 @@
 services:
     database_creator:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         command: ["createdb", "squid"]
         depends_on:
             database:

--- a/apps/cli/src/node/docker-compose-paymaster.yaml
+++ b/apps/cli/src/node/docker-compose-paymaster.yaml
@@ -1,6 +1,6 @@
 services:
     mock-verifying-paymaster:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         command: "mock-verifying-paymaster"
         environment:
             - ALTO_RPC=http://alto:4337

--- a/packages/mock-verifying-paymaster/docker-compose.yaml
+++ b/packages/mock-verifying-paymaster/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
     anvil:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         command: ["devnet", "--block-time", "${BLOCK_TIME:-5}"]
         healthcheck:
             test: ["CMD", "eth_isready"]
@@ -13,7 +13,7 @@ services:
             - 8545:8545
 
     alto:
-        image: cartesi/sdk:0.12.0-alpha.1
+        image: cartesi/sdk:0.12.0-alpha.3
         command:
             [
                 "alto",


### PR DESCRIPTION
Depends on: #81

A new minor version cartesi/sdk should be released before merging this PR.

---

This pull request includes several updates to the `@cartesi/cli` package, focusing on adding a new feature and updating dependencies. The most important changes include adding the `--enable-espresso` flag to the `cartesi run` command, updating Docker Compose configurations to use newer images, and adding support for the Espresso development node.

### New Feature:
* Added `--enable-espresso` flag to enable the Espresso development node in the `cartesi run` command (`apps/cli/src/commands/run.ts`). [[1]](diffhunk://#diff-0eda9573885c4c62dc779278a8b0e8dd493db82e70837b1886e71e09062b8a80R38-R42) [[2]](diffhunk://#diff-0eda9573885c4c62dc779278a8b0e8dd493db82e70837b1886e71e09062b8a80R161-R165)

### Dependency Updates:
* Updated Docker Compose configurations to use `cartesi/sdk:0.11.0` instead of `cartesi/sdk:0.10.0` (`apps/cli/src/node/docker-compose-anvil.yaml`, `apps/cli/src/node/docker-compose-bundler.yaml`, `apps/cli/src/node/docker-compose-paymaster.yaml`, `packages/mock-verifying-paymaster/docker-compose.yaml`). [[1]](diffhunk://#diff-4e2567b6365f4839be81ffba67c0960045900a89ef839a76ba08c8d7cb454719L3-R3) [[2]](diffhunk://#diff-4e2567b6365f4839be81ffba67c0960045900a89ef839a76ba08c8d7cb454719L22-R22) [[3]](diffhunk://#diff-20fd65c916a75b33482fdc2ab4f13908d68eed03378286fb8f771ee8c5dd9e7bL3-R3) [[4]](diffhunk://#diff-dd9ab5bc6dedd4e561f4bd0b327aebc454e0df48ed1e552bdb6e9c6cee02c52cL3-R3) [[5]](diffhunk://#diff-0451c2a8cb3764ee14a51753f04853ae799a3b44e8291fca486ce5d2160182cdL3-R3) [[6]](diffhunk://#diff-0451c2a8cb3764ee14a51753f04853ae799a3b44e8291fca486ce5d2160182cdL16-R16)
* Updated PostgreSQL image to `postgres:16-alpine` in Docker Compose configurations (`apps/cli/src/node/docker-compose-database.yaml`, `apps/cli/src/node/docker-compose-explorer.yaml`). [[1]](diffhunk://#diff-76a415ce550d1c011442a11912a8a38206ee815e3b1b60b019e218602852de0bL3-R3) [[2]](diffhunk://#diff-5c92ef11e6978d2739845cbcb3d7fc67f75580d2a59bab6741321392689ed4b1L3-R3)

### Support for Espresso Development Node:
* Added Docker Compose configuration for the Espresso development node (`apps/cli/src/node/docker-compose-espresso.yaml`).

### Documentation:
* Added a changeset file to document the addition of the `--enable-espresso` flag (`.changeset/fresh-mangos-wink.md`).