### PR TITLE
Add espresso-dev-node to SDK

### DIFF
--- a/.changeset/strong-walls-help.md
+++ b/.changeset/strong-walls-help.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+add espresso-dev-node binary

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -184,7 +184,7 @@ ADD --chmod=644 \
 RUN tar -xJf /usr/share/cartesi-machine/images/linux-headers.tar.xz -C / && \
     rm /usr/share/cartesi-machine/images/linux-headers.tar.xz
 
-COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/bin/
+COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/local/bin/
 
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -9,6 +9,10 @@ ARG NODEJS_VERSION
 ARG SU_EXEC_VERSION
 ARG ANVIL_VERSION
 ARG CARTESI_ROLLUPS_GRAPHQL_VERSION
+ARG ESPRESSO_DEV_NODE_TAG
+
+# https://github.com/EspressoSystems/espresso-sequencer/pkgs/container/espresso-sequencer%2Fespresso-dev-node
+FROM ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:${ESPRESSO_DEV_NODE_TAG} AS espresso-dev-node
 
 ################################################################################
 # base image
@@ -179,6 +183,8 @@ ADD --chmod=644 \
     /usr/share/cartesi-machine/images/linux-headers.tar.xz
 RUN tar -xJf /usr/share/cartesi-machine/images/linux-headers.tar.xz -C / && \
     rm /usr/share/cartesi-machine/images/linux-headers.tar.xz
+
+COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/bin/
 
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -17,5 +17,6 @@ target "default" {
     SU_EXEC_VERSION                   = "0.2"
     ANVIL_VERSION                     = "2044faec64f99a21f0e5f0094458a973612d0712"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.4"
+    ESPRESSO_DEV_NODE_TAG             = "20240925"
   }
 }

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -17,6 +17,6 @@ target "default" {
     SU_EXEC_VERSION                   = "0.2"
     ANVIL_VERSION                     = "2044faec64f99a21f0e5f0094458a973612d0712"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.4"
-    ESPRESSO_DEV_NODE_TAG             = "20240925"
+    ESPRESSO_DEV_NODE_TAG             = "20241120-patch2"
   }
 }


### PR DESCRIPTION
This pull request introduces the `espresso-dev-node` binary to the Cartesi SDK, including updates to the Dockerfile and configuration files to support this addition. The most important changes are summarized below:

### New Feature Addition:
* [`.changeset/strong-walls-help.md`](diffhunk://#diff-5ff7ded5e9ae647f2ff4df76bfd2de2ef3f77778412a303745f4feab719752c3R1-R5): Added a changeset note indicating the addition of the `espresso-dev-node` binary to the SDK. (`[.changeset/strong-walls-help.mdR1-R5](diffhunk://#diff-5ff7ded5e9ae647f2ff4df76bfd2de2ef3f77778412a303745f4feab719752c3R1-R5)`)

### Dockerfile Updates:
* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR9-R12): Introduced the `ESPRESSO_DEV_NODE_TAG` argument and added a new stage to pull the `espresso-dev-node` binary from the Espresso Systems GitHub container registry. (`[packages/sdk/DockerfileR9-R12](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR9-R12)`)
* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR152-R153): Updated the Dockerfile to copy the `espresso-dev-node` binary into `/usr/bin/`. (`[packages/sdk/DockerfileR152-R153](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR152-R153)`)

### Configuration Updates:
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bR17): Added the `ESPRESSO_DEV_NODE_TAG` variable to the default target configuration. (`[packages/sdk/docker-bake.hclR17](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bR17)`)