### PR TITLE
Refactor release workflow

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,15 +1,5 @@
 name: cli
 on:
-    workflow_call:
-        inputs:
-            release:
-                type: boolean
-                required: false
-        secrets:
-            NPM_TOKEN:
-                required: true
-            TURBO_TOKEN:
-                required: true
     pull_request:
         paths:
             - .github/workflows/cli.yaml
@@ -48,22 +38,14 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
-            - name: Test / Coverage
-              working-directory: ./apps/cli
-              run: pnpm run test:coverage
+            - name: Build
+              run: pnpm build --filter @cartesi/cli
+
+            - name: Test
+              run: pnpm test --filter @cartesi/cli
 
             - name: "Report Coverage"
               if: always()
               uses: davelosert/vitest-coverage-report-action@v2
               with:
                   working-directory: ./apps/cli
-
-            - name: Build
-              run: pnpm build --filter @cartesi/cli
-
-            - name: Publish
-              if: ${{ inputs.release }}
-              working-directory: ./apps/cli
-              run: pnpm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -1,15 +1,5 @@
 name: devnet
 on:
-    workflow_call:
-        inputs:
-            release:
-                type: boolean
-                required: false
-        secrets:
-            NPM_TOKEN:
-                required: true
-            TURBO_TOKEN:
-                required: true
     pull_request:
         paths:
             - .github/workflows/devnet.yaml
@@ -46,10 +36,3 @@ jobs:
 
             - name: Build
               run: pnpm build --filter @cartesi/devnet
-
-            - name: Publish
-              if: ${{ inputs.release }}
-              run: pnpm publish --access public
-              working-directory: packages/devnet
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -1,15 +1,5 @@
 name: paymaster
 on:
-    workflow_call:
-        inputs:
-            release:
-                type: boolean
-                required: false
-        secrets:
-            NPM_TOKEN:
-                required: true
-            TURBO_TOKEN:
-                required: true
     pull_request:
         paths:
             - .github/workflows/paymaster.yaml
@@ -48,10 +38,3 @@ jobs:
 
             - name: Build
               run: pnpm build --filter @cartesi/mock-verifying-paymaster
-
-            - name: Publish
-              if: ${{ inputs.release }}
-              working-directory: ./packages/mock-verifying-paymaster
-              run: pnpm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,19 @@ jobs:
             - name: Install Dependencies
               run: pnpm install
 
-            - name: Create Release Pull Request
+            - name: Build
+              run: pnpm build
+
+            - name: Test
+              run: pnpm test
+
+            - name: "Report Coverage"
+              if: always()
+              uses: davelosert/vitest-coverage-report-action@v2
+              with:
+                  working-directory: ./apps/cli
+
+            - name: Create Release Pull Request or Publish to npm
               id: changeset
               uses: changesets/action@v1
               with:
@@ -46,6 +58,7 @@ jobs:
                   publish: pnpm run publish-packages
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     packages_to_build:
         name: Get released packages
@@ -66,30 +79,3 @@ jobs:
         if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@cartesi/sdk') }}
         uses: ./.github/workflows/sdk.yaml
         secrets: inherit
-
-    build_devnet:
-        name: Build devnet
-        needs: [release, packages_to_build]
-        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@cartesi/devnet') }}
-        uses: ./.github/workflows/devnet.yaml
-        secrets: inherit
-        with:
-            release: true
-
-    build_cli:
-        name: Build cli
-        needs: [release, packages_to_build]
-        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@cartesi/cli') }}
-        uses: ./.github/workflows/cli.yaml
-        secrets: inherit
-        with:
-            release: true
-
-    build_paymaster:
-        name: Build paymaster
-        needs: [release, packages_to_build]
-        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@cartesi/mock-verifying-paymaster') }}
-        uses: ./.github/workflows/paymaster.yaml
-        secrets: inherit
-        with:
-            release: true

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -91,8 +91,7 @@
         "postpack": "rimraf oclif.manifest.json",
         "posttest": "pnpm lint",
         "prepack": "pnpm build && oclif manifest",
-        "test": "vitest",
-        "test:coverage": "vitest --coverage.enabled true"
+        "test": "vitest"
     },
     "engines": {
         "node": ">=18.0.0"

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         coverage: {
+            enabled: true,
             provider: "istanbul",
             reporter: ["text", "json-summary", "json"],
             reportOnFailure: true,

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "dev": "turbo run dev --parallel",
         "lint": "turbo run lint",
         "format": "prettier --write \"**/*.{cjs,css,json,md,mjs,ts,tsx}\"",
-        "publish-packages": "pnpm changeset tag && git push --follow-tags",
-        "preinstall": "npx only-allow pnpm"
+        "publish-packages": "pnpm changeset publish && git push --follow-tags",
+        "preinstall": "npx only-allow pnpm",
+        "test": "turbo test"
     },
     "devDependencies": {
         "@cartesi/eslint-config": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,10 @@
         "lint": {},
         "start": {
             "dependsOn": ["^build"]
+        },
+        "test": {
+            "outputs": ["coverage/**"],
+            "dependsOn": []
         }
     }
 }


### PR DESCRIPTION
`cli`, `devnet`, and `mock-verifying-paymaster` are npm packages published to the `@cartesi` npm organization.
Instead of publishing the package in a workflow_call from the `release` workflow, this changes the publishing to be done in the `release` workflow itself in the `Create Release Pull Request or Publish to npm` step.

The publishing of the `sdk` docker image is still done in a workflow_call.

This will fix the problem that happens in the pre-release scenario, because `changeset publish` handles the case of specifying the npm tag to `pnpm publish` automatically.
