### PR TITLE
Set default ram-image to always be /usr/share/cartesi-machine/images/linux.bin

### DIFF
--- a/.changeset/perfect-news-compare.md
+++ b/.changeset/perfect-news-compare.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+set default ram-image to always be '/usr/share/cartesi-machine/images/linux.bin'

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,5 +1,4 @@
 import bytes from "bytes";
-import os from "os";
 import { extname } from "path";
 import { TomlPrimitive, parse as parseToml } from "smol-toml";
 
@@ -74,10 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-const DEFAULT_RAM_IMAGE_DOCKER = "/usr/share/cartesi-machine/images/linux.bin";
-const DEFAULT_RAM_IMAGE_LINUX = "/usr/share/cartesi-machine/images/linux.bin";
-const DEFAULT_RAM_IMAGE_MAC =
-    "/opt/homebrew/share/cartesi-machine/images/linux.bin";
+const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
 export const DEFAULT_SDK = "cartesi/sdk:0.12.0-alpha.1";
 
 type Builder = "directory" | "docker" | "empty" | "none" | "tar";
@@ -172,15 +168,6 @@ export const defaultRootDriveConfig = (): DriveConfig => ({
     tags: [],
 });
 
-export const defaultRamImage = (): string => {
-    switch (os.platform()) {
-        case "darwin":
-            return DEFAULT_RAM_IMAGE_MAC;
-        default:
-            return DEFAULT_RAM_IMAGE_LINUX;
-    }
-};
-
 export const defaultMachineConfig = (): MachineConfig => ({
     assertRollingTemplate: undefined,
     bootargs: [],
@@ -190,7 +177,7 @@ export const defaultMachineConfig = (): MachineConfig => ({
     maxMCycle: undefined,
     noRollup: undefined,
     ramLength: DEFAULT_RAM,
-    ramImage: defaultRamImage(),
+    ramImage: DEFAULT_RAM_IMAGE,
     store: "image",
     user: undefined,
 });
@@ -368,7 +355,7 @@ const parseMachine = (value: TomlPrimitive): MachineConfig => {
         maxMCycle: parseOptionalNumber(toml["max-mcycle"]),
         noRollup: parseBoolean(toml["no-rollup"], false),
         ramLength: parseString(toml["ram-length"], DEFAULT_RAM),
-        ramImage: parseString(toml["ram-image"], defaultRamImage()),
+        ramImage: parseString(toml["ram-image"], DEFAULT_RAM_IMAGE),
         store: "image",
         user: parseOptionalString(toml.user),
     };


### PR DESCRIPTION
This sets the default ram-image path to always be `/usr/share/cartesi-machine/images/linux.bin`, regardless the system os.
This is the path inside the SDK image that contains the `linux.bin` as well, so it works if the user does not have `cartesi-machine` installed on the host, which falls back to executing inside the SDK image container.
If the user does have `cartesi-machine` installed, and the `linux.bin` image is located somewhere else, he will need to define the path in the `cartesi.toml` config file.
