### PR TITLE
feat(cli): bump postgres to 16

### DIFF
--- a/.changeset/slimy-fishes-kneel.md
+++ b/.changeset/slimy-fishes-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump postgresql to 16

--- a/apps/cli/src/node/docker-compose-database.yaml
+++ b/apps/cli/src/node/docker-compose-database.yaml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
             interval: 10s

--- a/apps/cli/src/node/docker-compose-explorer.yaml
+++ b/apps/cli/src/node/docker-compose-explorer.yaml
@@ -1,6 +1,6 @@
 services:
     database_creator:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         command: ["createdb", "squid"]
         depends_on:
             database:


### PR DESCRIPTION
This pull request includes updates to the Docker Compose configuration files to use a newer version of the PostgreSQL image.

Updates to Docker Compose configurations:

* [`apps/cli/src/node/docker-compose-database.yaml`](diffhunk://#diff-76a415ce550d1c011442a11912a8a38206ee815e3b1b60b019e218602852de0bL3-R3): Updated the PostgreSQL image from `postgres:15-alpine` to `postgres:16-alpine`.
* [`apps/cli/src/node/docker-compose-explorer.yaml`](diffhunk://#diff-5c92ef11e6978d2739845cbcb3d7fc67f75580d2a59bab6741321392689ed4b1L3-R3): Updated the PostgreSQL image from `postgres:15-alpine` to `postgres:16-alpine`.