### PR TITLE
chore(sdk): bump base image to debian:bookworm-20250113

### DIFF
--- a/.changeset/brown-sheep-fold.md
+++ b/.changeset/brown-sheep-fold.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump base image to debian:bookworm-20250113

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -4,7 +4,7 @@ target "docker-platforms" {}
 target "default" {
   inherits = ["docker-metadata-action", "docker-platforms"]
   args = {
-    BASE_IMAGE                        = "debian:bookworm-20241202"
+    BASE_IMAGE                        = "debian:bookworm-20250113"
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.18.1"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     ALTO_VERSION                      = "0.0.4"


### PR DESCRIPTION
This pull request includes a small change to the `packages/sdk/docker-bake.hcl` file. The change updates the `BASE_IMAGE` version to a more recent version.

* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL7-R7): Updated `BASE_IMAGE` from `debian:bookworm-20241202` to `debian:bookworm-20250113`.