### PR TITLE
Anvil 0.3.0

### DIFF
--- a/.changeset/fluffy-taxis-attend.md
+++ b/.changeset/fluffy-taxis-attend.md
@@ -1,0 +1,6 @@
+---
+"@cartesi/devnet": minor
+"@cartesi/sdk": minor
+---
+
+bump anvil to 0.3.0

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -34,6 +34,8 @@ jobs:
 
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  version: v0.3.0
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -31,7 +31,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly-2044faec64f99a21f0e5f0094458a973612d0712
+                  version: v0.3.0
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -32,6 +32,8 @@ jobs:
 
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  version: v0.3.0
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly-2044faec64f99a21f0e5f0094458a973612d0712
+                  version: v0.3.0
 
             - name: Install Dependencies
               run: pnpm install

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -140,7 +140,7 @@ ENV LANGUAGE=en_US:en
 
 # download anvil pre-compiled binaries
 ARG ANVIL_VERSION
-RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${ANVIL_VERSION}/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
+RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/v${ANVIL_VERSION}/foundry_v${ANVIL_VERSION}_linux_$(dpkg --print-architecture).tar.gz | \
     tar -zx -C /usr/local/bin
 
 # healthcheck script using net_listening JSON-RPC method

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -15,7 +15,7 @@ target "default" {
     CRANE_VERSION                     = "0.19.1"
     NODEJS_VERSION                    = "18.19.0"
     SU_EXEC_VERSION                   = "0.2"
-    ANVIL_VERSION                     = "2044faec64f99a21f0e5f0094458a973612d0712"
+    ANVIL_VERSION                     = "0.3.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.4"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch2"
   }


### PR DESCRIPTION
Upgrade anvil to version 0.3.0.
(now anvil will have a stable version scheme)
