### PR TITLE
chore: bump graphql to v2.3.5-node-20250128

### DIFF
--- a/.changeset/many-tomatoes-count.md
+++ b/.changeset/many-tomatoes-count.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+bump graphql to v2.3.5-node-20250128

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -16,7 +16,7 @@ target "default" {
     NODEJS_VERSION                    = "18.19.0"
     SU_EXEC_VERSION                   = "0.2"
     ANVIL_VERSION                     = "0.3.0"
-    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.4"
+    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.5-node-20250128"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch2"
     CARTESI_ESPRESSO_READER_VERSION   = "0.2.1-node-20250128"
   }


### PR DESCRIPTION
This pull request includes updates to the Cartesi SDK to bump the GraphQL version to v2.3.5-node-20250128.