### PR TITLE
chore(sdk): bump devnet to 2.0.0-alpha.3

### DIFF
--- a/.changeset/cuddly-moons-refuse.md
+++ b/.changeset/cuddly-moons-refuse.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump devnet to 2.0.0-alpha.3

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -9,7 +9,7 @@ target "default" {
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     ALTO_VERSION                      = "0.0.4"
     PAYMASTER_VERSION                 = "0.2.0"
-    DEVNET_VERSION                    = "2.0.0-alpha.2"
+    DEVNET_VERSION                    = "2.0.0-alpha.3"
     LINUX_KERNEL_VERSION              = "6.5.13-ctsi-1-v0.20.0"
     XGENEXT2_VERSION                  = "1.5.6"
     CRANE_VERSION                     = "0.19.1"


### PR DESCRIPTION
Depends on the correct release of `@cartesi/devnet:2.0.0-alpha.3` no npm.