### PR TITLE
feat(cli): add espresso-reader

### DIFF
--- a/.changeset/tasty-chairs-doubt.md
+++ b/.changeset/tasty-chairs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+add rollups-espresso-reader service

--- a/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
@@ -6,15 +6,11 @@ services:
             database:
                 condition: service_healthy
         environment:
-            PGHOST: ${PGHOST:-database}
-            PGPORT: ${PGPORT:-5432}
-            PGUSER: ${PGUSER:-postgres}
-            PGPASSWORD: ${PGPASSWORD:-password}
-            PGDATABASE: ${PGDATABASE:-postgres}
-
-    rollups-node:
-        environment:
-            CARTESI_FEATURE_INPUT_READER_ENABLED: false
+            PGHOST: database
+            PGPORT: 5432
+            PGUSER: postgres
+            PGPASSWORD: password
+            PGDATABASE: postgres
 
     espresso:
         image: ${CARTESI_SDK_IMAGE}
@@ -32,7 +28,7 @@ services:
         depends_on:
             espresso_database_creator:
                 condition: service_completed_successfully
-            database:
+            anvil:
                 condition: service_healthy
         environment:
             ESPRESSO_SEQUENCER_L1_PROVIDER: ${CARTESI_BLOCKCHAIN_HTTP_ENDPOINT:-http://anvil:8545}
@@ -46,6 +42,8 @@ services:
             ESPRESSO_SEQUENCER_POSTGRES_PASSWORD: password
             ESPRESSO_SEQUENCER_POSTGRES_DATABASE: sequencer
             ESPRESSO_SEQUENCER_ETH_MNEMONIC: ${CARTESI_AUTH_MNEMONIC:-test test test test test test test test test test test junk}
+            ESPRESSO_SEQUENCER_L1_POLLING_INTERVAL: "1s"
+            ESPRESSO_STATE_PROVER_UPDATE_INTERVAL: "1s"
         healthcheck:
             test:
                 [
@@ -60,9 +58,46 @@ services:
             timeout: 1s
             retries: 5
 
+    rollups-node:
+        environment:
+            CARTESI_FEATURE_INPUT_READER_ENABLED: false
+
+    espresso_reader_migration:
+        image: ${CARTESI_SDK_IMAGE}
+        command:
+            - migrate
+            - -source
+            - file:///usr/share/cartesi/rollups-espresso-reader/migrations
+            - -database
+            - postgres://postgres:password@database:5432/postgres?sslmode=disable&x-migrations-table=espresso_schema_migrations
+            - up
+        depends_on:
+            rollups-node-migration:
+                condition: service_completed_successfully
+
+    espresso_reader:
+        image: ${CARTESI_SDK_IMAGE}
+        command: ["cartesi-rollups-espresso-reader"]
+        env_file:
+            - ${CARTESI_BIN_PATH}/compose/rollups/default.env
+        ports:
+            - 8081
+        depends_on:
+            espresso_reader_migration:
+                condition: service_completed_successfully
+            espresso:
+                condition: service_healthy
+        environment:
+            CARTESI_POSTGRES_ENDPOINT: postgres://postgres:password@database:5432/postgres?sslmode=disable
+            ESPRESSO_SERVICE_ENDPOINT: ":8081"
+            ESPRESSO_BASE_URL: http://espresso:8770
+            ESPRESSO_NAMESPACE: 51025
+            ESPRESSO_STARTING_BLOCK: 101
+
     proxy:
         depends_on:
             espresso:
                 condition: service_healthy
         volumes:
             - ./proxy/espresso.yaml:/etc/traefik/conf.d/espresso.yaml
+            - ./proxy/espresso-reader.yaml:/etc/traefik/conf.d/espresso-reader.yaml

--- a/apps/cli/src/compose/rollups/proxy/espresso-reader.yaml
+++ b/apps/cli/src/compose/rollups/proxy/espresso-reader.yaml
@@ -1,0 +1,17 @@
+http:
+    routers:
+        espresso-reader:
+            rule: "PathPrefix(`/espresso/reader`)"
+            middlewares:
+                - "remove-espresso-reader-prefix"
+            service: espresso-reader
+    middlewares:
+        remove-espresso-reader-prefix:
+            replacePathRegex:
+                regex: "^/espresso/reader/(.*)"
+                replacement: "/$1"
+    services:
+        espresso-reader:
+            loadBalancer:
+                servers:
+                    - url: "http://espresso_reader:8081"


### PR DESCRIPTION
You can test this with:

```
pnpm build --filter @cartesi/cli
alias cartesi-dev=$PWD/apps/cli/dist/index.js
cartesi-dev create --branch=prerelease/sdk-12 --template=go my-go-dapp-v2 
cd my-go-dapp-v2
cartesi-dev build
cartesi-dev rollups start --services espresso,graphql
cartesi-dev rollups deploy
```

The `rollups-espresso-reader` endpoints should be available at:

- http://localhost:8080/espresso/reader/nonce
- http://localhost:8080/espresso/reader/submit
