### PR TITLE
refactor(cli): better prompt dependencies

### DIFF
--- a/.changeset/lazy-feet-explode.md
+++ b/.changeset/lazy-feet-explode.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+better prompt service dependency

--- a/apps/cli/src/node/docker-compose-anvil.yaml
+++ b/apps/cli/src/node/docker-compose-anvil.yaml
@@ -42,7 +42,11 @@ services:
             ]
 
     prompt:
-        image: debian:bookworm-slim
+        depends_on:
+            anvil:
+                condition: service_healthy
+            dapp_deployer:
+                condition: service_completed_successfully
         environment:
             PROMPT_TXT_01_ANVIL: "Anvil running at http://localhost:8545"
 

--- a/apps/cli/src/node/docker-compose-bundler.yaml
+++ b/apps/cli/src/node/docker-compose-bundler.yaml
@@ -31,7 +31,9 @@ services:
             - "100"
             - "--enable-debug-endpoints"
     prompt:
-        image: debian:bookworm-slim
+        depends_on:
+            alto:
+                condition: service_started
         environment:
             PROMPT_TXT_06_BUNDLER: "Bundler running at http://localhost:${CARTESI_LISTEN_PORT}/bundler/rpc"
 

--- a/apps/cli/src/node/docker-compose-explorer.yaml
+++ b/apps/cli/src/node/docker-compose-explorer.yaml
@@ -51,7 +51,9 @@ services:
                 condition: service_completed_successfully
 
     prompt:
-        image: debian:bookworm-slim
+        depends_on:
+            explorer:
+                condition: service_started
         environment:
             PROMPT_TXT_04_EXPLORER: "Explorer running at http://localhost:${CARTESI_LISTEN_PORT}/explorer/"
 

--- a/apps/cli/src/node/docker-compose-paymaster.yaml
+++ b/apps/cli/src/node/docker-compose-paymaster.yaml
@@ -7,7 +7,9 @@ services:
             - ANVIL_RPC=http://anvil:8545
 
     prompt:
-        image: debian:bookworm-slim
+        depends_on:
+            mock-verifying-paymaster:
+                condition: service_started
         environment:
             PROMPT_TXT_07_PAYMASTER: "Paymaster running at http://localhost:${CARTESI_LISTEN_PORT}/paymaster/"
 

--- a/apps/cli/src/node/docker-compose-validator.yaml
+++ b/apps/cli/src/node/docker-compose-validator.yaml
@@ -28,7 +28,9 @@ services:
                 condition: service_healthy
 
     prompt:
-        image: debian:bookworm-slim
+        depends_on:
+            validator:
+                condition: service_healthy
         environment:
             PROMPT_TXT_02_GRAPHQL: "GraphQL running at http://localhost:${CARTESI_LISTEN_PORT}/graphql"
             PROMPT_TXT_03_INSPECT: "Inspect running at http://localhost:${CARTESI_LISTEN_PORT}/inspect/"


### PR DESCRIPTION
This pull request includes changes to improve the dependency management of the `prompt` service in various Docker Compose configurations. The most important changes are the addition of `depends_on` conditions to ensure that the `prompt` service starts only after its dependencies are in the appropriate state.

Dependency management improvements:

* [`.changeset/lazy-feet-explode.md`](diffhunk://#diff-81aafa642b25cb7c852567754ad647b8076966759e9032c36f10fe572c1777fdR1-R5): Added a changeset file indicating a patch update for `@cartesi/cli` with a note on better prompt service dependency.
* [`apps/cli/src/node/docker-compose-anvil.yaml`](diffhunk://#diff-4e2567b6365f4839be81ffba67c0960045900a89ef839a76ba08c8d7cb454719L38-R48): Added `depends_on` conditions for `anvil` and `dapp_deployer` services to ensure the `prompt` service starts only after these services are healthy or completed successfully.
* [`apps/cli/src/node/docker-compose-bundler.yaml`](diffhunk://#diff-20fd65c916a75b33482fdc2ab4f13908d68eed03378286fb8f771ee8c5dd9e7bL34-R36): Added `depends_on` condition for the `alto` service to ensure the `prompt` service starts only after the `alto` service has started.
* [`apps/cli/src/node/docker-compose-explorer.yaml`](diffhunk://#diff-5c92ef11e6978d2739845cbcb3d7fc67f75580d2a59bab6741321392689ed4b1L54-R56): Added `depends_on` condition for the `explorer` service to ensure the `prompt` service starts only after the `explorer` service has started.
* [`apps/cli/src/node/docker-compose-paymaster.yaml`](diffhunk://#diff-dd9ab5bc6dedd4e561f4bd0b327aebc454e0df48ed1e552bdb6e9c6cee02c52cL10-R12): Added `depends_on` condition for the `mock-verifying-paymaster` service to ensure the `prompt` service starts only after the `mock-verifying-paymaster` service has started.
* [`apps/cli/src/node/docker-compose-validator.yaml`](diffhunk://#diff-97736c1f31d49c10ad0362dccd705aaf822d05b3ad0f70bb0f3770cbab50fb37L31-R33): Added `depends_on` condition for the `validator` service to ensure the `prompt` service starts only after the `validator` service is healthy.