### PR TITLE
chore(sdk): bump espresso-dev-node to 20241120-patch5

### DIFF
--- a/.changeset/red-tigers-drive.md
+++ b/.changeset/red-tigers-drive.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump espresso-dev-node to 20241120-patch5

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -17,7 +17,7 @@ target "default" {
     SU_EXEC_VERSION                   = "0.2"
     ANVIL_VERSION                     = "0.3.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.5-node-20250128"
-    ESPRESSO_DEV_NODE_TAG             = "20241120-patch2"
+    ESPRESSO_DEV_NODE_TAG             = "20241120-patch5"
     CARTESI_ESPRESSO_READER_VERSION   = "0.2.1-node-20250128"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `@cartesi/sdk` package and the `docker-bake.hcl` configuration file. The most important changes are:

Version updates:

* [`.changeset/red-tigers-drive.md`](diffhunk://#diff-f9dfb486d34f513bdd7f9430ced7f1ae0325a8b40b70b181c478aab530f94ecaR1-R5): Added a changeset to bump the `espresso-dev-node` version to `20241120-patch5`.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL20-R20): Updated the `ESPRESSO_DEV_NODE_TAG` to `20241120-patch5`.