### PR TITLE
feat(sdk): add migrate db files

### DIFF
--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -236,5 +236,14 @@ mkdir -p "$GRAPHQL_DEST_FOLDER"
 curl -L "https://github.com/cartesi/rollups-graphql/archive/refs/tags/v${CARTESI_ROLLUPS_GRAPHQL_VERSION}.tar.gz" | tar --wildcards -xz -C ${GRAPHQL_DEST_FOLDER} --strip-components=3 '*/migrations/*.sql'
 EOF
 
+# Get migration files for rollups-espresso-reader
+ARG CARTESI_ESPRESSO_READER_VERSION
+RUN <<EOF
+ESPRESSO_DEST_FOLDER="/usr/share/cartesi/rollups-espresso-reader/migrations"
+
+mkdir -p "$ESPRESSO_DEST_FOLDER"
+curl -L "https://github.com/cartesi/rollups-espresso-reader/archive/refs/tags/v${CARTESI_ESPRESSO_READER_VERSION}.tar.gz" | tar --wildcards -xz -C ${ESPRESSO_DEST_FOLDER} --strip-components=6 '*/migrations/*.sql'
+EOF
+
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -227,5 +227,14 @@ rm /tmp/migrate.deb
 migrate --version
 EOF
 
+# Get migration files for rollups-graphql
+ARG CARTESI_ROLLUPS_GRAPHQL_VERSION
+RUN <<EOF
+GRAPHQL_DEST_FOLDER="/usr/cartesi/share/rollups-graphql/migrations"
+
+mkdir -p "$GRAPHQL_DEST_FOLDER"
+curl -L "https://github.com/cartesi/rollups-graphql/archive/refs/tags/v${CARTESI_ROLLUPS_GRAPHQL_VERSION}.tar.gz" | tar --wildcards -xz -C ${GRAPHQL_DEST_FOLDER} --strip-components=3 '*/migrations/*.sql'
+EOF
+
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -198,5 +198,34 @@ RUN tar -xJf /usr/share/cartesi-machine/images/linux-headers.tar.xz -C / && \
 
 COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/local/bin/
 
+# Install migrate db cli
+ARG GO_MIGRATE_VERSION
+RUN <<EOF
+ARCH=$(dpkg --print-architecture || uname -m)
+case "$ARCH" in
+    amd64|x86_64)
+        MIGRATE_URL="https://github.com/golang-migrate/migrate/releases/download/v${GO_MIGRATE_VERSION}/migrate.linux-amd64.deb"
+        ;;
+    arm64|aarch64)
+        MIGRATE_URL="https://github.com/golang-migrate/migrate/releases/download/v${GO_MIGRATE_VERSION}/migrate.linux-arm64.deb"
+        ;;
+    armhf|armv7l)
+        MIGRATE_URL="https://github.com/golang-migrate/migrate/releases/download/v${GO_MIGRATE_VERSION}/migrate.linux-armv7.deb"
+        ;;
+    i386)
+        MIGRATE_URL="https://github.com/golang-migrate/migrate/releases/download/v${GO_MIGRATE_VERSION}/migrate.linux-386.deb"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+curl -fsSL "$MIGRATE_URL" -o /tmp/migrate.deb
+dpkg -i /tmp/migrate.deb
+rm /tmp/migrate.deb
+migrate --version
+EOF
+
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -16,7 +16,7 @@ target "default" {
     NODEJS_VERSION                    = "18.19.0"
     SU_EXEC_VERSION                   = "0.2"
     ANVIL_VERSION                     = "0.3.0"
-    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.5-node-20250128"
+    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.8"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch5"
     CARTESI_ESPRESSO_READER_VERSION   = "0.2.1-node-20250128"
     GO_MIGRATE_VERSION                = "4.18.2"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -19,5 +19,6 @@ target "default" {
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.5-node-20250128"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch5"
     CARTESI_ESPRESSO_READER_VERSION   = "0.2.1-node-20250128"
+    GO_MIGRATE_VERSION                = "4.18.2"
   }
 }


### PR DESCRIPTION
This update downloads and organizes migration SQL files into a structured folder hierarchy.
```
db/
 ├── rollups-graphql/
 │   └── migrations/
 │       ├── migration1.sql
 │       ├── migration2.sql
 │       └── migrationN.sql 
 ├── rollups-espresso-reader/
 │   └── migrations/
 │       ├── migration1.sql
 │       ├── migration2.sql
 │       └── migrationN.sql
 ```

Old PR https://github.com/cartesi/cli/pull/160