### PR TITLE
chore(sdk): bump rollups-espresso-reader to 0.2.3-node-20250128

### DIFF
--- a/.changeset/dirty-apricots-approve.md
+++ b/.changeset/dirty-apricots-approve.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump rollups-espresso-reader to 0.2.3-node-20250128

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -18,7 +18,7 @@ target "default" {
     ANVIL_VERSION                     = "0.3.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.8"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch6"
-    CARTESI_ESPRESSO_READER_VERSION   = "0.2.1-node-20250128"
+    CARTESI_ESPRESSO_READER_VERSION   = "0.2.3-node-20250128"
     GO_MIGRATE_VERSION                = "4.18.2"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `@cartesi/sdk` package and the `docker-bake.hcl` configuration file to bump the version of `rollups-espresso-reader`.

Version updates:

* [`.changeset/dirty-apricots-approve.md`](diffhunk://#diff-b0a6ecf51baf0578d635c723dedd266af1c1a48c4a708dd0e1cf3da8e307e424R1-R5): Added a changeset file to bump `rollups-espresso-reader` to version `0.2.3-node-20250128`.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL21-R21): Updated `CARTESI_ESPRESSO_READER_VERSION` to `0.2.3-node-20250128` to match the new version.