### PR TITLE
Bump explorer and explorer-api to latest v1.0.0-alpha tags

### DIFF
--- a/.changeset/gold-weeks-add.md
+++ b/.changeset/gold-weeks-add.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": minor
+---
+
+bump explorer-api to v1.0.0-alpha.3

--- a/.changeset/lazy-walls-shop.md
+++ b/.changeset/lazy-walls-shop.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": minor
+---
+
+bump explorer to v1.0.0-alpha.2

--- a/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
@@ -6,7 +6,7 @@ x-explorer_db_env: &explorer_db_env
 
 services:
     explorer_api:
-        image: ghcr.io/cartesi/rollups-explorer-api:pr-52
+        image: cartesi/rollups-explorer-api:1.0.0-alpha.3
         environment:
             <<: *explorer_db_env
             GQL_PORT: 4350
@@ -31,7 +31,7 @@ services:
                 condition: service_healthy
 
     squid_processor:
-        image: ghcr.io/cartesi/rollups-explorer-api:pr-52
+        image: cartesi/rollups-explorer-api:1.0.0-alpha.3
         environment:
             <<: *explorer_db_env
             CHAIN_IDS: ${CARTESI_BLOCKCHAIN_ID:-13370}
@@ -44,7 +44,7 @@ services:
                 condition: service_healthy
 
     explorer:
-        image: ghcr.io/cartesi/rollups-explorer:pr-269
+        image: cartesi/rollups-explorer:1.0.0-alpha.2
         expose:
             - 3000
         depends_on:

--- a/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
@@ -1,11 +1,14 @@
+x-explorer_db_env: &explorer_db_env
+    DB_NAME: explorer
+    DB_PORT: 5432
+    DB_HOST: database
+    DB_PASS: password
+
 services:
     explorer_api:
-        image: cartesi/rollups-explorer-api:0.5.0
+        image: ghcr.io/cartesi/rollups-explorer-api:pr-52
         environment:
-            DB_NAME: ${PGDATABASE:-squid}
-            DB_PORT: ${PGPORT:-5432}
-            DB_HOST: ${PGHOST:-database}
-            DB_PASS: ${PGPASSWORD:-password}
+            <<: *explorer_db_env
             GQL_PORT: 4350
         expose:
             - 4350
@@ -28,22 +31,20 @@ services:
                 condition: service_healthy
 
     squid_processor:
-        image: cartesi/rollups-explorer-api:0.5.0
+        image: ghcr.io/cartesi/rollups-explorer-api:pr-52
         environment:
-            CHAIN_ID: ${CHAIN_ID:-13370}
-            RPC_URL_31337: ${RPC_URL:-http://anvil:8545}
+            <<: *explorer_db_env
+            CHAIN_IDS: ${CARTESI_BLOCKCHAIN_ID:-13370}
+            RPC_URL_13370: ${RPC_URL:-http://anvil:8545}
             BLOCK_CONFIRMATIONS_13370: 0
-            DB_NAME: ${PGDATABASE:-squid}
-            DB_PORT: ${PGPORT:-5432}
-            DB_HOST: ${PGHOST:-database}
-            DB_PASS: ${PGPASSWORD:-password}
+            GENESIS_BLOCK_13370: 1
         command: ["sqd", "process:prod"]
         depends_on:
             database:
                 condition: service_healthy
 
     explorer:
-        image: cartesi/rollups-explorer:0.12.0
+        image: ghcr.io/cartesi/rollups-explorer:pr-269
         expose:
             - 3000
         depends_on:


### PR DESCRIPTION
This pull request introduces updates to the Cartesi CLI and its associated Docker Compose configurations to align with newer versions of the explorer and explorer API. The changes improve environment variable management and update service images to use pre-release versions from GitHub Container Registry.

### Updates to dependencies:

* [`.changeset/gold-weeks-add.md`](diffhunk://#diff-eb4d3a2b423b96f1e6b129be9f6e5d6464658e6f54557257364e44f92abe5af5R1-R5): Bumped `explorer-api` to version `v1.0.0-alpha.3` and marked the change as a minor update for `@cartesi/cli`.
* [`.changeset/lazy-walls-shop.md`](diffhunk://#diff-00f148c45de7f77030c575a4f9d1737b4565c9ac94b6ccd6be44e81d131c2eadR1-R5): Bumped `explorer` to version `v1.0.0-alpha.2` and marked the change as a minor update for `@cartesi/cli`.

### Docker Compose configuration improvements:

* `apps/cli/src/compose/rollups/docker-compose-explorer.yaml`: 
  - Introduced a reusable anchor `x-explorer_db_env` for database environment variables, simplifying the configuration.
  - Updated `explorer_api`, `squid_processor`, and `explorer` service images to use pre-release versions from the GitHub Container Registry (`ghcr.io`). [[1]](diffhunk://#diff-efe73958c750db050f2d879840c2133120965ed708ed8201c2226d581aded79aR1-R11) [[2]](diffhunk://#diff-efe73958c750db050f2d879840c2133120965ed708ed8201c2226d581aded79aL31-R47)
  - Enhanced the `squid_processor` service configuration to use `CHAIN_IDS` and `RPC_URL_13370` instead of hardcoded values, improving flexibility.