### PR TITLE
add initialized postgres database to SDK

### DIFF
--- a/.changeset/honest-zoos-remember.md
+++ b/.changeset/honest-zoos-remember.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+add initialized postgres database

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -9,6 +9,7 @@ ARG ESPRESSO_DEV_NODE_TAG
 ARG FOUNDRY_VERSION
 ARG LINUX_KERNEL_VERSION
 ARG NODEJS_VERSION
+ARG POSTGRES_VERSION
 ARG SU_EXEC_VERSION
 ARG XGENEXT2_VERSION
 
@@ -130,6 +131,12 @@ curl -fsSL "https://github.com/cartesi/rollups-espresso-reader/archive/refs/tags
 EOF
 
 ################################################################################
+# postgresql initdb
+FROM postgres:${POSTGRES_VERSION} AS postgresql-initdb
+ENV POSTGRES_PASSWORD=password
+RUN /usr/local/bin/docker-ensure-initdb.sh postgres
+
+################################################################################
 # sdk final image
 FROM base
 ARG ALTO_VERSION
@@ -212,6 +219,7 @@ COPY --from=graphql-migration /usr/share/cartesi/rollups-graphql/migrations /usr
 COPY --from=espresso-reader /usr/local/bin/cartesi-rollups-espresso-reader /usr/local/bin/
 COPY --from=espresso-reader-migration /usr/share/cartesi/rollups-espresso-reader/migrations /usr/share/cartesi/rollups-espresso-reader/migrations
 COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/local/bin/
+COPY --from=postgresql-initdb /var/lib/postgresql/data /var/lib/postgresql/data
 
 RUN mkdir -p /tmp/.cartesi && chmod 1777 /tmp/.cartesi
 

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -18,6 +18,7 @@ target "default" {
     LINUX_KERNEL_VERSION              = "6.5.13-ctsi-1-v0.20.0"
     NODEJS_VERSION                    = "18.19.0"
     PAYMASTER_VERSION                 = "0.2.0"
+    POSTGRES_VERSION                  = "16"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }


### PR DESCRIPTION
This is part of the effort to make the cli start faster.

EDIT: Don't think it's worth the effort of running migration during sdk build for now.

~Things that could also be added to this PR but I'd like to open to discussion are:~

- [ ] ~run `cartesi-rollups-cli db upgrade`~
- [ ] ~rollups-graph migrations to  `/docker-entrypoint-initdb.d`~
- [ ] ~espresso-reader migrations to `/docker-entrypoint-initdb.d`~

See: #177 