### PR TITLE
Add cartesi-rollups-node-v2.0.0-alpha.1 to SDK

### DIFF
--- a/.changeset/bright-dodos-double.md
+++ b/.changeset/bright-dodos-double.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+add cartesi-rollups-node-2.0.0-alpha.1

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -142,6 +142,7 @@ FROM base
 ARG ALTO_VERSION
 ARG CARTESI_IMAGE_KERNEL_VERSION
 ARG CARTESI_MACHINE_EMULATOR_VERSION
+ARG CARTESI_ROLLUPS_NODE_VERSION
 ARG DEVNET_VERSION
 ARG LINUX_KERNEL_VERSION
 ARG PAYMASTER_VERSION
@@ -248,6 +249,15 @@ echo "2ecdb9c9f02a96faed2605ec811ef7188f963feb21b32d057b1ab3278f27ac42887f235a3f
     | sha512sum -c
 tar -xJf "/tmp/linux-headers-${LINUX_KERNEL_VERSION}.tar.xz" -C /
 rm "/tmp/linux-headers-${LINUX_KERNEL_VERSION}.tar.xz"
+EOF
+
+# Install cartesi-rollups-node
+RUN <<EOF
+curl -fsSL https://github.com/cartesi/rollups-node/releases/download/v${CARTESI_ROLLUPS_NODE_VERSION}/cartesi-rollups-node-v${CARTESI_ROLLUPS_NODE_VERSION%%-*}_${TARGETARCH}.deb \
+    -o /tmp/cartesi-rollups-node.deb
+dpkg -i /tmp/cartesi-rollups-node.deb
+rm /tmp/cartesi-rollups-node.deb
+cartesi-rollups-node --version
 EOF
 
 WORKDIR /mnt

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -10,6 +10,7 @@ target "default" {
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.18.1"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.8"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.1"
     CRANE_VERSION                     = "0.19.1"
     DEVNET_VERSION                    = "2.0.0-alpha.3"
     ESPRESSO_DEV_NODE_TAG             = "20241120-patch6"


### PR DESCRIPTION
Install the debian package of `cartesi-rollups-node-v2.0.0-alpha.1`

ps: version is defined as `2.0.0-alpha.1`, which is the GitHub release version, but Debian file name is `2.0.0` only. So I had to use a bash trick to remove everything after the `-` using `${CARTESI_ROLLUPS_NODE_VERSION%%-*}`