### PR TITLE
Change verbose behavior

### DIFF
--- a/.changeset/evil-colts-rule.md
+++ b/.changeset/evil-colts-rule.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+add rollups logs command

--- a/.changeset/kind-chicken-take.md
+++ b/.changeset/kind-chicken-take.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+change verbose behavior

--- a/apps/cli/src/commands/rollups.ts
+++ b/apps/cli/src/commands/rollups.ts
@@ -1,5 +1,6 @@
 import { Command } from "@commander-js/extra-typings";
 import { createDeployCommand } from "./rollups/deploy.js";
+import { createLogsCommand } from "./rollups/logs.js";
 import { createStartCommand } from "./rollups/start.js";
 import { createStatusCommand } from "./rollups/status.js";
 import { createStopCommand } from "./rollups/stop.js";
@@ -14,6 +15,7 @@ export const createRollupsCommand = () => {
         .action(async (_options, program) => {
             program.help();
         });
+    command.addCommand(createLogsCommand());
     command.addCommand(createStartCommand());
     command.addCommand(createStatusCommand());
     command.addCommand(createStopCommand());

--- a/apps/cli/src/commands/rollups/logs.ts
+++ b/apps/cli/src/commands/rollups/logs.ts
@@ -1,0 +1,53 @@
+import { Command } from "@commander-js/extra-typings";
+import { execa } from "execa";
+import { RollupsCommandOpts } from "../rollups.js";
+
+export const createLogsCommand = () => {
+    return new Command<[], {}, RollupsCommandOpts>("logs")
+        .description("Show logs of a local rollups node environment.")
+        .option("-f, --follow", "Follow log output")
+        .option("--no-color", "Produce monochrome output")
+        .option("--no-log-prefix", "Don't print prefix in logs")
+        .option(
+            "--since <string>",
+            "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)",
+        )
+        .option(
+            "-n, --tail <string>",
+            "Number of lines to show from the end of the logs",
+            "all",
+        )
+        .option("-t, --timestamps", "Show timestamps")
+        .option(
+            "--until <string>",
+            "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)",
+        )
+        .configureHelp({ showGlobalOptions: true })
+        .action(
+            async (
+                { follow, color, logPrefix, since, tail, timestamps, until },
+                command,
+            ) => {
+                const { projectName } = command.optsWithGlobals();
+                const logOptions: string[] = [];
+                if (follow) logOptions.push("--follow");
+                if (color === false) logOptions.push("--no-color");
+                if (logPrefix === false) logOptions.push("--no-log-prefix");
+                if (since) logOptions.push("--since", since);
+                if (tail) logOptions.push("--tail", tail);
+                if (timestamps) logOptions.push("--timestamps");
+                await execa(
+                    "docker",
+                    [
+                        "compose",
+                        "-p",
+                        projectName,
+                        "logs",
+                        ...logOptions,
+                        "rollups-node",
+                    ],
+                    { stdio: "inherit" },
+                );
+            },
+        );
+};

--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -199,10 +199,9 @@ export const createStartCommand = () => {
 
             // setup the environment variable used in docker compose
             const env: NodeJS.ProcessEnv = {
-                ANVIL_VERBOSITY: verbose ? "--steps-tracing" : "--silent",
                 BLOCK_TIME: blockTime.toString(),
                 CARTESI_BLOCKCHAIN_DEFAULT_BLOCK: defaultBlock,
-                CARTESI_LOG_LEVEL: verbose ? "info" : "error",
+                CARTESI_LOG_LEVEL: verbose ? "debug" : "info",
                 CARTESI_BIN_PATH: binPath,
                 CARTESI_LISTEN_PORT: port.toString(),
                 CARTESI_ROLLUPS_NODE_CPUS: cpus?.toString(),

--- a/apps/cli/src/compose/rollups/docker-compose-anvil.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-anvil.yaml
@@ -1,13 +1,7 @@
 services:
     anvil:
         image: ${CARTESI_SDK_IMAGE}
-        command:
-            [
-                "devnet",
-                "--block-time",
-                "${BLOCK_TIME:-5}",
-                "${ANVIL_VERBOSITY:---silent}",
-            ]
+        command: ["devnet", "--block-time", "${BLOCK_TIME:-5}"]
         healthcheck:
             test: ["CMD", "eth_isready"]
             start_period: 10s


### PR DESCRIPTION
This removes the `rollups start --verbose` flag.
Log level of rollups-node is set to "info".

Maybe we should still have the flag, and set rollups-node level to "debug" in case of verbose?