### PR TITLE
Change default block to latest

### DIFF
--- a/.changeset/spicy-bananas-hope.md
+++ b/.changeset/spicy-bananas-hope.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+change default block to 'latest'

--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -156,7 +156,7 @@ export const createStartCommand = () => {
                 "default block to be used when fetching new blocks.",
             )
                 .choices(["latest", "safe", "pending", "finalized"])
-                .default("finalized"),
+                .default("latest"),
         )
         .addOption(
             new Option(
@@ -258,6 +258,13 @@ export const createStartCommand = () => {
                     stdio: "inherit",
                 });
             } else {
+                if (defaultBlock !== "finalized") {
+                    console.warn(
+                        chalk.yellow(
+                            `WARNING: default block is set to '${defaultBlock}', production configuration will likely use 'finalized'`,
+                        ),
+                    );
+                }
                 // pull images first
                 await execa("docker", [...composeArgs, "pull"], {
                     env,


### PR DESCRIPTION
This changes the default node block to `latest`, instead of `finalized`.
As discussed on discord this is better for development.

We also discussed the possibility of printing a warn message.
