### PR TITLE
Simplify  rollups logs

### DIFF
--- a/apps/cli/src/commands/rollups/logs.ts
+++ b/apps/cli/src/commands/rollups/logs.ts
@@ -7,7 +7,6 @@ export const createLogsCommand = () => {
         .description("Show logs of a local rollups node environment.")
         .option("-f, --follow", "Follow log output")
         .option("--no-color", "Produce monochrome output")
-        .option("--no-log-prefix", "Don't print prefix in logs")
         .option(
             "--since <string>",
             "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)",
@@ -17,37 +16,29 @@ export const createLogsCommand = () => {
             "Number of lines to show from the end of the logs",
             "all",
         )
-        .option("-t, --timestamps", "Show timestamps")
         .option(
             "--until <string>",
             "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)",
         )
         .configureHelp({ showGlobalOptions: true })
-        .action(
-            async (
-                { follow, color, logPrefix, since, tail, timestamps, until },
-                command,
-            ) => {
-                const { projectName } = command.optsWithGlobals();
-                const logOptions: string[] = [];
-                if (follow) logOptions.push("--follow");
-                if (color === false) logOptions.push("--no-color");
-                if (logPrefix === false) logOptions.push("--no-log-prefix");
-                if (since) logOptions.push("--since", since);
-                if (tail) logOptions.push("--tail", tail);
-                if (timestamps) logOptions.push("--timestamps");
-                await execa(
-                    "docker",
-                    [
-                        "compose",
-                        "-p",
-                        projectName,
-                        "logs",
-                        ...logOptions,
-                        "rollups-node",
-                    ],
-                    { stdio: "inherit" },
-                );
-            },
-        );
+        .action(async ({ follow, color, since, tail, until }, command) => {
+            const { projectName } = command.optsWithGlobals();
+            const logOptions: string[] = ["--no-log-prefix"];
+            if (follow) logOptions.push("--follow");
+            if (color === false) logOptions.push("--no-color");
+            if (since) logOptions.push("--since", since);
+            if (tail) logOptions.push("--tail", tail);
+            await execa(
+                "docker",
+                [
+                    "compose",
+                    "-p",
+                    projectName,
+                    "logs",
+                    ...logOptions,
+                    "rollups-node",
+                ],
+                { stdio: "inherit" },
+            );
+        });
 };


### PR DESCRIPTION
Since rollups-node is the only service that will have its logs shown, I suggest:

- Using `--no-log-prefix` as default
- Hide the `--timestamps` option since rollups-node service already prefixes timestamps by default

