### PR TITLE
Change from --project-name to --environment-name

### DIFF
--- a/apps/cli/src/base.ts
+++ b/apps/cli/src/base.ts
@@ -82,16 +82,16 @@ export const getAddressBook = async (): Promise<AddressBook> => {
 };
 
 const getServiceInfo = async (options: {
-    projectName: string;
+    environmentName: string;
     service: string;
 }): Promise<PsResponse | undefined> => {
-    const { projectName, service } = options;
+    const { environmentName, service } = options;
 
     // get service information
     const { stdout } = await execa("docker", [
         "compose",
         "--project-name",
-        projectName,
+        environmentName,
         "ps",
         service,
         "--format",
@@ -101,7 +101,7 @@ const getServiceInfo = async (options: {
 };
 
 export const getServiceState = async (options: {
-    projectName: string;
+    environmentName: string;
     service: string;
 }): Promise<string | undefined> => {
     const info = await getServiceInfo(options);
@@ -109,7 +109,7 @@ export const getServiceState = async (options: {
 };
 
 export const getServiceHealth = async (options: {
-    projectName: string;
+    environmentName: string;
     service: string;
 }): Promise<string | undefined> => {
     const info = await getServiceInfo(options);

--- a/apps/cli/src/commands/rollups.ts
+++ b/apps/cli/src/commands/rollups.ts
@@ -8,7 +8,7 @@ import { createStopCommand } from "./rollups/stop.js";
 export const createRollupsCommand = () => {
     const command = new Command("rollups")
         .option(
-            "--project-name <string>",
+            "--environment-name <string>",
             "name of environment",
             "cartesi-rollups",
         )

--- a/apps/cli/src/commands/rollups/deploy.ts
+++ b/apps/cli/src/commands/rollups/deploy.ts
@@ -147,17 +147,17 @@ const deployApplication = async (
  */
 const publishMachine = async (options: {
     progress: Ora;
-    projectName: string;
+    environmentName: string;
     templateHash: Hash;
 }): Promise<string> => {
-    const { progress, projectName, templateHash } = options;
+    const { progress, environmentName, templateHash } = options;
     const snapshotPath = getContextPath("image");
     const containerSnapshotPath = `/var/lib/cartesi-rollups-node/snapshots/${templateHash}/`;
     progress.start("Publishing machine snapshot...");
     await execa("docker", [
         "compose",
         "--project-name",
-        projectName,
+        environmentName,
         "cp",
         snapshotPath,
         `rollups-node:${containerSnapshotPath}`,
@@ -175,10 +175,11 @@ const registerApplication = async (options: {
     applicationAddress: Address;
     name?: string;
     progress: Ora;
-    projectName: string;
+    environmentName: string;
     snapshotPath: string;
 }): Promise<string> => {
-    const { applicationAddress, progress, projectName, snapshotPath } = options;
+    const { applicationAddress, progress, environmentName, snapshotPath } =
+        options;
 
     // use template hash as the name of the deployment
     const name =
@@ -193,7 +194,7 @@ const registerApplication = async (options: {
     const { stdout } = await execa("docker", [
         "compose",
         "--project-name",
-        projectName,
+        environmentName,
         "exec",
         "rollups-node",
         "cartesi-rollups-cli",
@@ -257,7 +258,7 @@ export const createDeployCommand = () => {
         .option("--json", "output in JSON format")
         .action(async (options, command) => {
             const rollupsOptions = command.optsWithGlobals();
-            const { projectName } = rollupsOptions;
+            const { environmentName } = rollupsOptions;
             const { json } = options;
             // XXX: json support is not implemented yet
             // if case of json maybe we should not support interactive mode
@@ -300,7 +301,7 @@ export const createDeployCommand = () => {
                     const containerSnapshotPath = await publishMachine({
                         progress,
                         templateHash,
-                        projectName,
+                        environmentName,
                     });
 
                     const name = await registerApplication({

--- a/apps/cli/src/commands/rollups/logs.ts
+++ b/apps/cli/src/commands/rollups/logs.ts
@@ -22,7 +22,7 @@ export const createLogsCommand = () => {
         )
         .configureHelp({ showGlobalOptions: true })
         .action(async ({ follow, color, since, tail, until }, command) => {
-            const { projectName } = command.optsWithGlobals();
+            const { environmentName } = command.optsWithGlobals();
             const logOptions: string[] = ["--no-log-prefix"];
             if (follow) logOptions.push("--follow");
             if (color === false) logOptions.push("--no-color");
@@ -32,8 +32,8 @@ export const createLogsCommand = () => {
                 "docker",
                 [
                     "compose",
-                    "-p",
-                    projectName,
+                    "--project-name",
+                    environmentName,
                     "logs",
                     ...logOptions,
                     "rollups-node",

--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -109,9 +109,9 @@ const availableServices: Service[] = [
 ];
 
 const serviceMonitorTask = (options: {
+    environmentName: string;
     errorTitle?: string;
     healthyTitle?: string;
-    projectName: string;
     service: string;
     waitTitle?: string;
 }): ListrTask => {
@@ -180,7 +180,7 @@ export const createStartCommand = () => {
         .option("--dry-run", "show the docker compose configuration", false)
         .option("-v, --verbose", "verbose output", false)
         .action(async (options, command) => {
-            const { projectName } = command.optsWithGlobals();
+            const { environmentName } = command.optsWithGlobals();
             const {
                 blockTime,
                 cpus,
@@ -245,7 +245,7 @@ export const createStartCommand = () => {
                 "compose",
                 ...files,
                 "--project-name",
-                projectName,
+                environmentName,
             ];
 
             // run in detached mode (background)
@@ -285,7 +285,7 @@ export const createStartCommand = () => {
                                 ? service.healthyTitle(port)
                                 : service.healthyTitle;
                         return serviceMonitorTask({
-                            projectName,
+                            environmentName,
                             service: service.healthySemaphore!,
                             errorTitle: service.errorTitle,
                             waitTitle: service.waitTitle,

--- a/apps/cli/src/commands/rollups/status.ts
+++ b/apps/cli/src/commands/rollups/status.ts
@@ -11,12 +11,12 @@ export const createStatusCommand = () => {
         .configureHelp({ showGlobalOptions: true })
         .option("--json", "output in JSON format")
         .action(async ({ json }, command) => {
-            const { projectName } = command.optsWithGlobals();
+            const { environmentName } = command.optsWithGlobals();
             const status = await getServiceState({
-                projectName,
+                environmentName,
                 service: "rollups-node",
             });
-            const deployments = await getDeployments({ projectName });
+            const deployments = await getDeployments({ environmentName });
 
             if (json) {
                 process.stdout.write(
@@ -27,7 +27,7 @@ export const createStatusCommand = () => {
                 );
             } else {
                 console.log(
-                    `${chalk.cyan(projectName)} is ${status == "running" ? chalk.green("running") : chalk.red("not running")}`,
+                    `${chalk.cyan(environmentName)} is ${status == "running" ? chalk.green("running") : chalk.red("not running")}`,
                 );
 
                 if (status === "running") {

--- a/apps/cli/src/commands/rollups/stop.ts
+++ b/apps/cli/src/commands/rollups/stop.ts
@@ -9,20 +9,20 @@ export const createStopCommand = () => {
         .description("Stop a local rollups node environment.")
         .configureHelp({ showGlobalOptions: true })
         .action(async (_options, command) => {
-            const { projectName } = command.optsWithGlobals();
+            const { environmentName } = command.optsWithGlobals();
             const progress = ora(
-                `Stopping ${chalk.cyan(projectName)} environment...`,
+                `Stopping ${chalk.cyan(environmentName)} environment...`,
             ).start();
             try {
                 await execa("docker", [
                     "compose",
                     "-p",
-                    projectName,
+                    environmentName,
                     "down",
                     "--volumes",
                 ]);
                 progress.succeed(
-                    `${chalk.cyan(projectName)} environment stopped.`,
+                    `${chalk.cyan(environmentName)} environment stopped.`,
                 );
             } catch (e: unknown) {
                 progress.fail((e as Error).message);

--- a/apps/cli/src/exec/rollups.ts
+++ b/apps/cli/src/exec/rollups.ts
@@ -12,18 +12,18 @@ export type RollupsDeployment = {
 };
 
 type ComposeParams = {
-    projectName?: string;
+    environmentName?: string;
 };
 
 export const getDeployments = async (
     options?: ComposeParams,
 ): Promise<RollupsDeployment[]> => {
-    const projectName = options?.projectName ?? "cartesi-rollups";
+    const environmentName = options?.environmentName ?? "cartesi-rollups";
     try {
         const { stdout } = await execa("docker", [
             "compose",
             "--project-name",
-            projectName,
+            environmentName,
             "exec",
             "rollups-node",
             "cartesi-rollups-cli",


### PR DESCRIPTION
The param name `project-name` does not make sense in the context of `rollups` commands.
