### PR TITLE
Migrations from entrypoints

### DIFF
--- a/apps/cli/src/compose/rollups/docker-compose-database.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-database.yaml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: postgres:16-alpine
+        image: postgres:16
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
             start_period: 10s

--- a/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
@@ -1,6 +1,6 @@
 services:
     espresso_database_creator:
-        image: postgres:16-alpine
+        image: postgres:16
         command: ["createdb", "sequencer"]
         depends_on:
             database:

--- a/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
@@ -1,6 +1,6 @@
 services:
     database_creator:
-        image: postgres:16-alpine
+        image: postgres:16
         command: ["createdb", "squid"]
         depends_on:
             database:

--- a/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
@@ -12,19 +12,6 @@ services:
             PGPASSWORD: password
             PGDATABASE: postgres
 
-    graphql_database_migration:
-        image: ${CARTESI_SDK_IMAGE}
-        command:
-            - migrate
-            - -path
-            - /usr/share/cartesi/rollups-graphql/migrations
-            - -database
-            - postgres://postgres:password@database:5432/graphql?sslmode=disable
-            - up
-        depends_on:
-            graphql_database_creator:
-                condition: service_completed_successfully
-
     graphql:
         image: ${CARTESI_SDK_IMAGE}
         environment:
@@ -32,6 +19,15 @@ services:
             POSTGRES_NODE_DB_URL: postgres://postgres:password@database:5432/postgres?sslmode=disable
         expose:
             - 8080
+        entrypoint:
+            - /bin/sh
+            - -c
+            - |
+                migrate \
+                    -path /usr/share/cartesi/rollups-graphql/migrations \
+                    -database postgres://postgres:password@database:5432/graphql?sslmode=disable \
+                    up && \
+                exec "$0" "$@"
         command: ["cartesi-rollups-graphql"]
         healthcheck:
             test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
@@ -41,7 +37,7 @@ services:
             timeout: 1s
             retries: 5
         depends_on:
-            graphql_database_migration:
+            graphql_database_creator:
                 condition: service_completed_successfully
 
     proxy:

--- a/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
@@ -1,6 +1,6 @@
 services:
     graphql_database_creator:
-        image: postgres:16-alpine
+        image: postgres:16
         command: ["createdb", "graphql"]
         depends_on:
             database:

--- a/apps/cli/src/compose/rollups/docker-compose-node.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-node.yaml
@@ -1,19 +1,9 @@
 services:
-    rollups-node-migration:
-        image: ${CARTESI_SDK_IMAGE}
-        command: ["cartesi-rollups-cli", "db", "upgrade"]
-        depends_on:
-            database:
-                condition: service_healthy
-        restart: "no"
-        env_file:
-            - ${CARTESI_BIN_PATH}/compose/rollups/default.env
-
     rollups-node:
         image: ${CARTESI_SDK_IMAGE}
         depends_on:
-            rollups-node-migration:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
             anvil:
                 condition: service_healthy
         expose:
@@ -27,6 +17,10 @@ services:
             interval: 10s
             timeout: 1s
             retries: 5
+        entrypoint:
+            - /bin/sh
+            - -c
+            - 'cartesi-rollups-cli db upgrade && exec "$0" "$@"'
         command: ["cartesi-rollups-node"]
         env_file:
             - ${CARTESI_BIN_PATH}/compose/rollups/default.env

--- a/apps/cli/src/compose/rollups/docker-compose-paymaster.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-paymaster.yaml
@@ -1,5 +1,5 @@
 services:
-    mock-verifying-paymaster:
+    paymaster:
         image: ${CARTESI_SDK_IMAGE}
         command: "mock-verifying-paymaster"
         environment:


### PR DESCRIPTION
This pull request includes several updates to the Docker Compose configurations for various services. The main changes involve updating the PostgreSQL image and simplifying the service definitions by merging migration steps into the main service entrypoints.

Updates to PostgreSQL image:

* [`apps/cli/src/compose/rollups/docker-compose-database.yaml`](diffhunk://#diff-ab80ca76fe4a2efe23ed8c048ebc142d1f99d8c9fb5b4995e835a6404db64bdfL3-R3): Updated the PostgreSQL image from `postgres:16-alpine` to `postgres:16`.
* [`apps/cli/src/compose/rollups/docker-compose-espresso.yaml`](diffhunk://#diff-0343d89d288e5a884ea7f3274623db9d8f05a9f75a5b12ebdaaa484e6f5cf8dfL3-R3): Updated the PostgreSQL image from `postgres:16-alpine` to `postgres:16`.
* [`apps/cli/src/compose/rollups/docker-compose-explorer.yaml`](diffhunk://#diff-efe73958c750db050f2d879840c2133120965ed708ed8201c2226d581aded79aL3-R3): Updated the PostgreSQL image from `postgres:16-alpine` to `postgres:16`.
* [`apps/cli/src/compose/rollups/docker-compose-graphql.yaml`](diffhunk://#diff-930f4b0b8ee548f6105ea28bce2fd9a5036f2f07b6488bc21e02f137cc401a89L3-R3): Updated the PostgreSQL image from `postgres:16-alpine` to `postgres:16`.

Simplification of service definitions:

* [`apps/cli/src/compose/rollups/docker-compose-graphql.yaml`](diffhunk://#diff-930f4b0b8ee548f6105ea28bce2fd9a5036f2f07b6488bc21e02f137cc401a89L15-R30): Removed the `graphql_database_migration` service and integrated the migration commands into the `graphql` service entrypoint. Updated dependencies accordingly. [[1]](diffhunk://#diff-930f4b0b8ee548f6105ea28bce2fd9a5036f2f07b6488bc21e02f137cc401a89L15-R30) [[2]](diffhunk://#diff-930f4b0b8ee548f6105ea28bce2fd9a5036f2f07b6488bc21e02f137cc401a89L44-R40)
* [`apps/cli/src/compose/rollups/docker-compose-node.yaml`](diffhunk://#diff-632478dee158cf846d3cc88ebfb87ccfbf18d367cc2c9dfb36c252da688cc4a3L2-L16): Removed the `rollups-node-migration` service and integrated the migration commands into the `rollups-node` service entrypoint. Updated dependencies accordingly. [[1]](diffhunk://#diff-632478dee158cf846d3cc88ebfb87ccfbf18d367cc2c9dfb36c252da688cc4a3L2-L16) [[2]](diffhunk://#diff-632478dee158cf846d3cc88ebfb87ccfbf18d367cc2c9dfb36c252da688cc4a3R20-R23)
* [`apps/cli/src/compose/rollups/docker-compose-paymaster.yaml`](diffhunk://#diff-e99d43a9071d4fe8820eeea4103862ebc9c14650f067e65d7a7793b8ed6e1707L2-R2): Renamed `mock-verifying-paymaster` service to `paymaster` for consistency.