### PR TITLE
Fix CLI tests by locking a SDK version

### DIFF
--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -66,8 +66,8 @@ const availableServices: Service[] = [
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
             `Service ${chalk.cyan("bundler")} ready at ${chalk.cyan(`${host}:${port}/bundler/rpc`)}`,
-        waitTitle: `Starting ${chalk.cyan("bundler")}...`,
-        errorTitle: `Service ${chalk.red("bundler")} failed`,
+        waitTitle: `${chalk.cyan("bundler")} service starting...`,
+        errorTitle: `${chalk.red("bundler")} service failed`,
     },
     {
         name: "espresso",
@@ -75,8 +75,8 @@ const availableServices: Service[] = [
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
             `Service ${chalk.cyan("espresso")} ready at ${chalk.cyan(`${host}:${port}/espresso`)}`,
-        waitTitle: `Starting ${chalk.cyan("espresso")}...`,
-        errorTitle: `Service ${chalk.red("espresso")} failed`,
+        waitTitle: `${chalk.cyan("espresso")} service starting...`,
+        errorTitle: `${chalk.red("espresso")} service failed`,
     },
     {
         name: "explorer",
@@ -84,8 +84,8 @@ const availableServices: Service[] = [
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
             `Service ${chalk.cyan("explorer")} ready at ${chalk.cyan(`${host}:${port}/explorer`)}`,
-        waitTitle: `Starting ${chalk.cyan("explorer")}...`,
-        errorTitle: `Service ${chalk.red("explorer")} failed`,
+        waitTitle: `${chalk.cyan("explorer")} service starting...`,
+        errorTitle: `${chalk.red("explorer")} service failed`,
     },
     {
         name: "graphql",
@@ -93,8 +93,8 @@ const availableServices: Service[] = [
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
             `Service ${chalk.cyan("graphql")} ready at ${chalk.cyan(`${host}:${port}/graphql`)}`,
-        waitTitle: `Starting ${chalk.cyan("graphql")}...`,
-        errorTitle: `Service ${chalk.red("graphql")} failed`,
+        waitTitle: `${chalk.cyan("graphql")} service starting...`,
+        errorTitle: `${chalk.red("graphql")} service failed`,
     },
     {
         name: "paymaster",

--- a/apps/cli/tests/integration/builder/directory.test.ts
+++ b/apps/cli/tests/integration/builder/directory.test.ts
@@ -1,12 +1,13 @@
 import fs from "fs-extra";
 import path from "path";
 import { describe, expect } from "vitest";
-import { build } from "../../../src/builder/directory";
-import { DEFAULT_SDK, DirectoryDriveConfig } from "../../../src/config";
-import { tmpdirTest } from "./tmpdirTest";
+import { build } from "../../../src/builder/directory.js";
+import { DirectoryDriveConfig } from "../../../src/config.js";
+import { TEST_SDK } from "../config.js";
+import { tmpdirTest } from "./tmpdirTest.js";
 
 describe("when building with the directory builder", () => {
-    const image = DEFAULT_SDK;
+    const image = TEST_SDK;
 
     tmpdirTest(
         "should fail when the directory doesn't exists",

--- a/apps/cli/tests/integration/builder/docker.test.ts
+++ b/apps/cli/tests/integration/builder/docker.test.ts
@@ -2,12 +2,13 @@ import fs from "fs-extra";
 import { beforeEach } from "node:test";
 import path from "path";
 import { describe, expect } from "vitest";
-import { build } from "../../../src/builder/docker";
-import { DEFAULT_SDK, DockerDriveConfig } from "../../../src/config";
-import { tmpdirTest } from "./tmpdirTest";
+import { build } from "../../../src/builder/docker.js";
+import { DockerDriveConfig } from "../../../src/config.js";
+import { TEST_SDK } from "../config.js";
+import { tmpdirTest } from "./tmpdirTest.js";
 
 describe("when building with the docker builder", () => {
-    const image = DEFAULT_SDK;
+    const image = TEST_SDK;
 
     beforeEach(({ name }) => {
         fs.mkdirpSync(path.join(__dirname, "output", name));
@@ -35,6 +36,7 @@ describe("when building with the docker builder", () => {
         const drive: DockerDriveConfig = {
             builder: "docker",
             context: path.join(__dirname, "data"),
+            dockerfile: "Dockerfile",
             extraSize: 0,
             format: "ext2",
             tags: [],

--- a/apps/cli/tests/integration/builder/empty.test.ts
+++ b/apps/cli/tests/integration/builder/empty.test.ts
@@ -1,12 +1,13 @@
 import fs from "fs-extra";
 import path from "path";
 import { describe, expect } from "vitest";
-import { build } from "../../../src/builder/empty";
-import { DEFAULT_SDK, EmptyDriveConfig } from "../../../src/config";
-import { tmpdirTest } from "./tmpdirTest";
+import { build } from "../../../src/builder/empty.js";
+import { EmptyDriveConfig } from "../../../src/config.js";
+import { TEST_SDK } from "../config.js";
+import { tmpdirTest } from "./tmpdirTest.js";
 
 describe("when building with the empty builder", () => {
-    const image = DEFAULT_SDK;
+    const image = TEST_SDK;
 
     tmpdirTest("should fail with an invalid size", async ({ tmpdir }) => {
         const destination = tmpdir;

--- a/apps/cli/tests/integration/builder/none.test.ts
+++ b/apps/cli/tests/integration/builder/none.test.ts
@@ -1,9 +1,9 @@
 import fs from "fs-extra";
 import path from "path";
 import { describe, expect } from "vitest";
-import { build } from "../../../src/builder/none";
-import { ExistingDriveConfig } from "../../../src/config";
-import { tmpdirTest } from "./tmpdirTest";
+import { build } from "../../../src/builder/none.js";
+import { ExistingDriveConfig } from "../../../src/config.js";
+import { tmpdirTest } from "./tmpdirTest.js";
 
 describe("when building with the none builder", () => {
     tmpdirTest("should not build a missing file", async ({ tmpdir }) => {

--- a/apps/cli/tests/integration/builder/tar.test.ts
+++ b/apps/cli/tests/integration/builder/tar.test.ts
@@ -1,12 +1,13 @@
 import fs from "fs-extra";
 import path from "path";
 import { describe, expect } from "vitest";
-import { build } from "../../../src/builder/tar";
-import { DEFAULT_SDK, TarDriveConfig } from "../../../src/config";
-import { tmpdirTest } from "./tmpdirTest";
+import { build } from "../../../src/builder/tar.js";
+import { TarDriveConfig } from "../../../src/config.js";
+import { TEST_SDK } from "../config.js";
+import { tmpdirTest } from "./tmpdirTest.js";
 
 describe("when building with the tar builder", () => {
-    const image = DEFAULT_SDK;
+    const image = TEST_SDK;
 
     tmpdirTest("should not build a missing file", async ({ tmpdir }) => {
         const destination = tmpdir;

--- a/apps/cli/tests/integration/config.ts
+++ b/apps/cli/tests/integration/config.ts
@@ -1,0 +1,1 @@
+export const TEST_SDK = "cartesi/sdk:0.12.0-alpha.10";

--- a/apps/cli/tests/integration/exec/cartesi-machine.test.ts
+++ b/apps/cli/tests/integration/exec/cartesi-machine.test.ts
@@ -1,13 +1,13 @@
 import { satisfies } from "semver";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SDK } from "../../../src/config.js";
 import { cartesiMachine } from "../../../src/exec/index.js";
+import { TEST_SDK } from "../config.js";
 
 describe("cartesi-machine", () => {
     it("should report version", async () => {
         const version = await cartesiMachine.version({
             forceDocker: true,
-            image: DEFAULT_SDK,
+            image: TEST_SDK,
         });
         expect(version).toBeDefined();
         expect(

--- a/apps/cli/tests/integration/exec/crane.test.ts
+++ b/apps/cli/tests/integration/exec/crane.test.ts
@@ -1,13 +1,13 @@
 import { satisfies } from "semver";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SDK } from "../../../src/config.js";
 import { crane } from "../../../src/exec/index.js";
+import { TEST_SDK } from "../config.js";
 
 describe("crane", () => {
     it("should report version", async () => {
         const version = await crane.version({
             forceDocker: true,
-            image: DEFAULT_SDK,
+            image: TEST_SDK,
         });
         expect(version).toBeDefined();
         expect(

--- a/apps/cli/tests/integration/exec/genext2fs.test.ts
+++ b/apps/cli/tests/integration/exec/genext2fs.test.ts
@@ -1,13 +1,13 @@
 import { satisfies } from "semver";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SDK } from "../../../src/config.js";
 import { genext2fs } from "../../../src/exec/index.js";
+import { TEST_SDK } from "../config.js";
 
 describe("genext2fs", () => {
     it("should report version", async () => {
         const version = await genext2fs.version({
             forceDocker: true,
-            image: DEFAULT_SDK,
+            image: TEST_SDK,
         });
 
         expect(version).toBeDefined();

--- a/apps/cli/tests/integration/exec/mksquashfs.test.ts
+++ b/apps/cli/tests/integration/exec/mksquashfs.test.ts
@@ -1,13 +1,13 @@
 import { satisfies } from "semver";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SDK } from "../../../src/config.js";
 import { mksquashfs } from "../../../src/exec/index.js";
+import { TEST_SDK } from "../config.js";
 
 describe("mksquashfs", () => {
     it("should report version", async () => {
         const version = await mksquashfs.version({
             forceDocker: true,
-            image: DEFAULT_SDK,
+            image: TEST_SDK,
         });
         expect(version).toBeDefined();
         expect(


### PR DESCRIPTION
The CLI CI tests uses a SDK version. This PR locks a version of a SDK.
We can think about a better solution for this in a future PR.