### PR TITLE
Fix bundler startup and improve overall time

### DIFF
--- a/.changeset/cool-crews-rest.md
+++ b/.changeset/cool-crews-rest.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+fix name of bundler service

--- a/.changeset/new-hotels-follow.md
+++ b/.changeset/new-hotels-follow.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+improve startup time

--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -65,7 +65,7 @@ const availableServices: Service[] = [
         file: "docker-compose-bundler.yaml",
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
-            `Service ${chalk.cyan("bundler")} ready at ${chalk.cyan(`${host}:${port}/bundler/rpc`)}`,
+            `${chalk.cyan("bundler")} service ready at ${chalk.cyan(`${host}:${port}/bundler/rpc`)}`,
         waitTitle: `${chalk.cyan("bundler")} service starting...`,
         errorTitle: `${chalk.red("bundler")} service failed`,
     },
@@ -74,7 +74,7 @@ const availableServices: Service[] = [
         file: "docker-compose-espresso.yaml",
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
-            `Service ${chalk.cyan("espresso")} ready at ${chalk.cyan(`${host}:${port}/espresso`)}`,
+            `${chalk.cyan("espresso")} service ready at ${chalk.cyan(`${host}:${port}/espresso`)}`,
         waitTitle: `${chalk.cyan("espresso")} service starting...`,
         errorTitle: `${chalk.red("espresso")} service failed`,
     },
@@ -83,7 +83,7 @@ const availableServices: Service[] = [
         file: "docker-compose-explorer.yaml",
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
-            `Service ${chalk.cyan("explorer")} ready at ${chalk.cyan(`${host}:${port}/explorer`)}`,
+            `${chalk.cyan("explorer")} service ready at ${chalk.cyan(`${host}:${port}/explorer`)}`,
         waitTitle: `${chalk.cyan("explorer")} service starting...`,
         errorTitle: `${chalk.red("explorer")} service failed`,
     },
@@ -92,7 +92,7 @@ const availableServices: Service[] = [
         file: "docker-compose-graphql.yaml",
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
-            `Service ${chalk.cyan("graphql")} ready at ${chalk.cyan(`${host}:${port}/graphql`)}`,
+            `${chalk.cyan("graphql")} service ready at ${chalk.cyan(`${host}:${port}/graphql`)}`,
         waitTitle: `${chalk.cyan("graphql")} service starting...`,
         errorTitle: `${chalk.red("graphql")} service failed`,
     },
@@ -101,9 +101,9 @@ const availableServices: Service[] = [
         file: "docker-compose-paymaster.yaml",
         healthySemaphore: "proxy",
         healthyTitle: (port) =>
-            `Service ${chalk.cyan("paymaster")} ready at ${chalk.cyan(`${host}:${port}/paymaster`)}`,
-        waitTitle: `Starting ${chalk.cyan("paymaster")}...`,
-        errorTitle: `Service ${chalk.red("paymaster")} failed`,
+            `${chalk.cyan("paymaster")} service ready at ${chalk.cyan(`${host}:${port}/paymaster`)}`,
+        waitTitle: `${chalk.cyan("paymaster")} service starting...`,
+        errorTitle: `${chalk.red("paymaster")} service failed`,
     },
 ];
 

--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -42,7 +42,7 @@ const baseServices: Service[] = [
     {
         name: "rpc",
         file: "docker-compose-node.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "rollups-node",
         healthyTitle: (port) =>
             `${chalk.cyan("rpc")} service ready at ${chalk.cyan(`${host}:${port}/rpc`)}`,
         waitTitle: `${chalk.cyan("rpc")} service starting...`,
@@ -51,7 +51,7 @@ const baseServices: Service[] = [
     {
         name: "inspect",
         file: "docker-compose-node.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "rollups-node",
         healthyTitle: (port) =>
             `${chalk.cyan("inspect")} service ready at ${chalk.cyan(`${host}:${port}/inspect/<application_address>`)}`,
         waitTitle: `${chalk.cyan("inspect")} service starting...`,
@@ -63,7 +63,7 @@ const availableServices: Service[] = [
     {
         name: "bundler",
         file: "docker-compose-bundler.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "bundler",
         healthyTitle: (port) =>
             `${chalk.cyan("bundler")} service ready at ${chalk.cyan(`${host}:${port}/bundler/rpc`)}`,
         waitTitle: `${chalk.cyan("bundler")} service starting...`,
@@ -72,7 +72,7 @@ const availableServices: Service[] = [
     {
         name: "espresso",
         file: "docker-compose-espresso.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "espresso",
         healthyTitle: (port) =>
             `${chalk.cyan("espresso")} service ready at ${chalk.cyan(`${host}:${port}/espresso`)}`,
         waitTitle: `${chalk.cyan("espresso")} service starting...`,
@@ -81,7 +81,7 @@ const availableServices: Service[] = [
     {
         name: "explorer",
         file: "docker-compose-explorer.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "explorer_api",
         healthyTitle: (port) =>
             `${chalk.cyan("explorer")} service ready at ${chalk.cyan(`${host}:${port}/explorer`)}`,
         waitTitle: `${chalk.cyan("explorer")} service starting...`,
@@ -90,7 +90,7 @@ const availableServices: Service[] = [
     {
         name: "graphql",
         file: "docker-compose-graphql.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "graphql",
         healthyTitle: (port) =>
             `${chalk.cyan("graphql")} service ready at ${chalk.cyan(`${host}:${port}/graphql`)}`,
         waitTitle: `${chalk.cyan("graphql")} service starting...`,
@@ -99,7 +99,7 @@ const availableServices: Service[] = [
     {
         name: "paymaster",
         file: "docker-compose-paymaster.yaml",
-        healthySemaphore: "proxy",
+        healthySemaphore: "paymaster",
         healthyTitle: (port) =>
             `${chalk.cyan("paymaster")} service ready at ${chalk.cyan(`${host}:${port}/paymaster`)}`,
         waitTitle: `${chalk.cyan("paymaster")} service starting...`,

--- a/apps/cli/src/compose/rollups/docker-compose-bundler.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-bundler.yaml
@@ -39,8 +39,5 @@ services:
             retries: 5
 
     proxy:
-        depends_on:
-            bundler:
-                condition: service_healthy
         volumes:
             - ./proxy/bundler.yaml:/etc/traefik/conf.d/bundler.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-bundler.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-bundler.yaml
@@ -1,5 +1,5 @@
 services:
-    alto:
+    bundler:
         image: ${CARTESI_SDK_IMAGE}
         command:
             - "alto"

--- a/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
@@ -95,9 +95,6 @@ services:
             ESPRESSO_STARTING_BLOCK: 101
 
     proxy:
-        depends_on:
-            espresso:
-                condition: service_healthy
         volumes:
             - ./proxy/espresso.yaml:/etc/traefik/conf.d/espresso.yaml
             - ./proxy/espresso-reader.yaml:/etc/traefik/conf.d/espresso-reader.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
@@ -64,11 +64,6 @@ services:
                 condition: service_completed_successfully
 
     proxy:
-        depends_on:
-            explorer_api:
-                condition: service_healthy
-            explorer:
-                condition: service_healthy
         volumes:
             - ./proxy/explorer.yaml:/etc/traefik/conf.d/explorer.yaml
             - ./proxy/explorer-api.yaml:/etc/traefik/conf.d/explorer-api.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
@@ -45,8 +45,5 @@ services:
                 condition: service_completed_successfully
 
     proxy:
-        depends_on:
-            graphql:
-                condition: service_healthy
         volumes:
             - ./proxy/graphql.yaml:/etc/traefik/conf.d/graphql.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-node.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-node.yaml
@@ -32,8 +32,5 @@ services:
             - ${CARTESI_BIN_PATH}/compose/rollups/default.env
 
     proxy:
-        depends_on:
-            rollups-node:
-                condition: service_healthy
         volumes:
             - ./proxy/rollups-node.yaml:/etc/traefik/conf.d/rollups-node.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-paymaster.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-paymaster.yaml
@@ -14,8 +14,5 @@ services:
             retries: 5
 
     proxy:
-        depends_on:
-            paymaster:
-                condition: service_healthy
         volumes:
             - ./proxy/paymaster.yaml:/etc/traefik/conf.d/paymaster.yaml

--- a/apps/cli/src/compose/rollups/docker-compose-proxy.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-proxy.yaml
@@ -17,6 +17,8 @@ services:
                 "--metrics.prometheus.addServicesLabels=true",
                 "--providers.file.directory=/etc/traefik/conf.d",
                 "--providers.file.watch=true",
+                "--log",
+                "--log.level=INFO",
             ]
         ports:
             - ${CARTESI_LISTEN_PORT:-8080}:8088


### PR DESCRIPTION
This fixes the name of the bundler service.
Also I removed the dependency of the proxy service on the other services, relying on the monitoring of the proxy configuration files. 
Actually what happens is that the proxy container is up with all service configuration files already there. And I changed the status check to look for the healthy status of the service itself, not the proxy.
This way the services can be ready at their own pace.
