### PR TITLE
ci: pin GitHub Actions commit hash

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -32,18 +32,18 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
 
             - name: Install dependencies
               run: pnpm install
@@ -54,7 +54,7 @@ jobs:
 
             - name: "Report Coverage"
               if: always()
-              uses: davelosert/vitest-coverage-report-action@v2
+              uses: davelosert/vitest-coverage-report-action@5a78cb16e761204097ad8a39369ea5d0ff7c8a5d # v2.8.0
               with:
                   working-directory: ./apps/cli
 

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -29,17 +29,17 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -30,18 +30,18 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,26 +21,26 @@ jobs:
             publishedPackages: ${{ steps.changeset.outputs.publishedPackages }}
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
 
             - name: Install Dependencies
               run: pnpm install
 
             - name: Create Release Pull Request
               id: changeset
-              uses: changesets/action@v1
+              uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
               with:
                   commit: "release: version packages"
                   publish: pnpm run publish-packages

--- a/.github/workflows/rm-closed-pr-images.yaml
+++ b/.github/workflows/rm-closed-pr-images.yaml
@@ -15,7 +15,7 @@ jobs:
                 image:
                     - sdk
         steps:
-            - uses: vlaurin/action-ghcr-prune@v0.6.0
+            - uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 # v0.6.0
               with:
                   organization: cartesi
                   container: ${{ matrix.image }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Get package tag/version
               id: package-version
@@ -33,7 +33,7 @@ jobs:
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
               with:
                   images: |
                       docker.io/cartesi/sdk,enable=${{ github.event_name != 'pull_request' }}
@@ -46,23 +46,23 @@ jobs:
                       org.opencontainers.image.description=Cartesi SDK tools image
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Login to DockerHub
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/bake-action@v5
+              uses: docker/bake-action@4a9a8d494466d37134e2bfca2d3a8de8fb2681ad # v5.13.0
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   workdir: packages/sdk
@@ -75,9 +75,9 @@ jobs:
                       *.cache-to=type=gha,mode=max
                   push: true
 
-            - uses: depot/setup-action@v1
+            - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
             - name: Build and push (depot)
-              uses: depot/bake-action@v1
+              uses: depot/bake-action@58d7160c6bfa64eb85e384209e6f2f5ad17948bb # v1.11.0
               if: ${{ startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   project: ${{ vars.DEPOT_PROJECT }}


### PR DESCRIPTION
See: https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash

Since we already have dependabot acting on github-actions, whenever some GH action has an update to the version, we shall get a PR to update it to the new commit hash.