### PR TITLE
ci: pin GitHub Actions commit hash

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -22,18 +22,18 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
               with:
                   version: v0.3.0
 
@@ -48,6 +48,6 @@ jobs:
 
             - name: "Report Coverage"
               if: always()
-              uses: davelosert/vitest-coverage-report-action@v2
+              uses: davelosert/vitest-coverage-report-action@5a78cb16e761204097ad8a39369ea5d0ff7c8a5d # v2.8.0
               with:
                   working-directory: ./apps/cli

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -19,17 +19,17 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
               with:
                   version: v0.3.0
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -20,18 +20,18 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
               with:
                   version: v0.3.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,19 +21,19 @@ jobs:
             publishedPackages: ${{ steps.changeset.outputs.publishedPackages }}
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
             - name: Setup Node.js 20
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version: 20
                   cache: "pnpm"
 
             - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
+              uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
               with:
                   version: v0.3.0
 
@@ -48,13 +48,13 @@ jobs:
 
             - name: "Report Coverage"
               if: always()
-              uses: davelosert/vitest-coverage-report-action@v2
+              uses: davelosert/vitest-coverage-report-action@5a78cb16e761204097ad8a39369ea5d0ff7c8a5d # v2.8.0
               with:
                   working-directory: ./apps/cli
 
             - name: Create Release Pull Request or Publish to npm
               id: changeset
-              uses: changesets/action@v1
+              uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
               with:
                   commit: "release: version packages"
                   publish: pnpm run publish-packages

--- a/.github/workflows/rm-closed-pr-images.yaml
+++ b/.github/workflows/rm-closed-pr-images.yaml
@@ -15,7 +15,7 @@ jobs:
                 image:
                     - sdk
         steps:
-            - uses: vlaurin/action-ghcr-prune@v0.6.0
+            - uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 # v0.6.0
               with:
                   organization: cartesi
                   container: ${{ matrix.image }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Get package tag/version
               id: package-version
@@ -33,7 +33,7 @@ jobs:
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
               with:
                   images: |
                       docker.io/cartesi/sdk,enable=${{ github.event_name != 'pull_request' }}
@@ -46,23 +46,23 @@ jobs:
                       org.opencontainers.image.description=Cartesi SDK tools image
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Login to DockerHub
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/bake-action@v5
+              uses: docker/bake-action@4a9a8d494466d37134e2bfca2d3a8de8fb2681ad # v5.13.0
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   workdir: packages/sdk
@@ -75,9 +75,9 @@ jobs:
                       *.cache-to=type=gha,mode=max
                   push: true
 
-            - uses: depot/setup-action@v1
+            - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
             - name: Build and push (depot)
-              uses: depot/bake-action@v1
+              uses: depot/bake-action@58d7160c6bfa64eb85e384209e6f2f5ad17948bb # v1.11.0
               if: ${{ startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   project: ${{ vars.DEPOT_PROJECT }}


### PR DESCRIPTION
This pull request updates several GitHub Action workflows to use specific commit SHAs for improved reliability and consistency. The changes affect multiple workflows, ensuring that the actions used are locked to a specific version.

Updates to GitHub Action workflows:

* [`.github/workflows/cli.yaml`](diffhunk://#diff-b186cdccd59addc2f6171a64b1c1e97f5759efec23139108f6702ce661b1d370L25-R36): Updated `actions/checkout` to `v4.2.2`, `pnpm/action-setup` to `v4.1.0`, `actions/setup-node` to `v4.3.0`, `foundry-rs/foundry-toolchain` to `1.3.1`, and `davelosert/vitest-coverage-report-action` to `v2.8.0`. [[1]](diffhunk://#diff-b186cdccd59addc2f6171a64b1c1e97f5759efec23139108f6702ce661b1d370L25-R36) [[2]](diffhunk://#diff-b186cdccd59addc2f6171a64b1c1e97f5759efec23139108f6702ce661b1d370L51-R51)
* [`.github/workflows/devnet.yaml`](diffhunk://#diff-bad657be2bd0addbff22cb204b2d1227d6353f693a17d165fb963889af857213L22-R32): Updated `actions/checkout` to `v4.2.2`, `pnpm/action-setup` to `v4.1.0`, `actions/setup-node` to `v4.3.0`, and `foundry-rs/foundry-toolchain` to `1.3.1`.
* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL14-R18): Updated `actions/checkout` to `v4.2.2`, `pnpm/action-setup` to `v4.1.0`, and `actions/setup-node` to `v4.3.0`.
* [`.github/workflows/paymaster.yaml`](diffhunk://#diff-3fff960f0299dc2d6f132de5174ac5010676003f89c0e385b7e78ec29205608fL23-R34): Updated `actions/checkout` to `v4.2.2`, `pnpm/action-setup` to `v4.1.0`, `actions/setup-node` to `v4.3.0`, and `foundry-rs/foundry-toolchain` to `1.3.1`.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL24-R36): Updated `actions/checkout` to `v4.2.2`, `pnpm/action-setup` to `v4.1.0`, `actions/setup-node` to `v4.3.0`, `foundry-rs/foundry-toolchain` to `1.3.1`, `davelosert/vitest-coverage-report-action` to `v2.8.0`, and `changesets/action` to `v1.4.10`. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL24-R36) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL51-R57)
* [`.github/workflows/rm-closed-pr-images.yaml`](diffhunk://#diff-d4c2bf7951eb0673e50061ed83748baae61bb15c98cafe23fac0096a175bdc34L18-R18): Updated `vlaurin/action-ghcr-prune` to `v0.6.0`.
* [`.github/workflows/sdk.yaml`](diffhunk://#diff-cc4c3b7d1957bd74724832a1038fed3a23bcd1aa7440b1452bc9bb96fd508dbcL26-R26): Updated `actions/checkout` to `v4.2.2`, `docker/metadata-action` to `v5.7.0`, `docker/setup-buildx-action` to `v3.10.0`, `docker/login-action` to `v3.4.0`, `docker/bake-action` to `v5.13.0`, `depot/setup-action` to `v1.6.0`, and `depot/bake-action` to `v1.11.0`. [[1]](diffhunk://#diff-cc4c3b7d1957bd74724832a1038fed3a23bcd1aa7440b1452bc9bb96fd508dbcL26-R26) [[2]](diffhunk://#diff-cc4c3b7d1957bd74724832a1038fed3a23bcd1aa7440b1452bc9bb96fd508dbcL36-R36) [[3]](diffhunk://#diff-cc4c3b7d1957bd74724832a1038fed3a23bcd1aa7440b1452bc9bb96fd508dbcL49-R65) [[4]](diffhunk://#diff-cc4c3b7d1957bd74724832a1038fed3a23bcd1aa7440b1452bc9bb96fd508dbcL78-R80)