### PR TITLE
cli to use pre-initialized database

### DIFF
--- a/apps/cli/src/commands/rollups/start.ts
+++ b/apps/cli/src/commands/rollups/start.ts
@@ -5,7 +5,7 @@ import { Listr, ListrTask } from "listr2";
 import pRetry from "p-retry";
 import path from "path";
 import { getServiceHealth } from "../../base.js";
-import { DEFAULT_SDK } from "../../config.js";
+import { DEFAULT_SDK_IMAGE, DEFAULT_SDK_VERSION } from "../../config.js";
 import { RollupsCommandOpts } from "../rollups.js";
 
 const commaSeparatedList = (value: string) => value.split(",");
@@ -205,7 +205,8 @@ export const createStartCommand = () => {
                 CARTESI_LISTEN_PORT: port.toString(),
                 CARTESI_ROLLUPS_NODE_CPUS: cpus?.toString(),
                 CARTESI_ROLLUPS_NODE_MEMORY: memory?.toString(),
-                CARTESI_SDK_IMAGE: DEFAULT_SDK,
+                CARTESI_SDK_IMAGE: DEFAULT_SDK_IMAGE,
+                CARTESI_SDK_VERSION: DEFAULT_SDK_VERSION,
             };
 
             // build a list of unique compose files

--- a/apps/cli/src/compose/rollups/default.env
+++ b/apps/cli/src/compose/rollups/default.env
@@ -32,4 +32,4 @@ CARTESI_CONTRACTS_AUTHORITY_FACTORY_ADDRESS="${CARTESI_CONTRACTS_AUTHORITY_FACTO
 CARTESI_AUTH_MNEMONIC="${CARTESI_AUTH_MNEMONIC:-test test test test test test test test test test test junk}"
 
 # postgres
-CARTESI_DATABASE_CONNECTION="postgres://postgres:password@database:5432/postgres?sslmode=disable"
+CARTESI_DATABASE_CONNECTION="postgres://postgres:password@database:5432/rollupsdb?sslmode=disable"

--- a/apps/cli/src/compose/rollups/docker-compose-database.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-database.yaml
@@ -1,6 +1,6 @@
 services:
     database:
-        image: postgres:16
+        image: cartesi/rollups-database:${CARTESI_SDK_VERSION}
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
             start_period: 10s

--- a/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-espresso.yaml
@@ -1,17 +1,4 @@
 services:
-    espresso_database_creator:
-        image: postgres:16
-        command: ["createdb", "sequencer"]
-        depends_on:
-            database:
-                condition: service_healthy
-        environment:
-            PGHOST: database
-            PGPORT: 5432
-            PGUSER: postgres
-            PGPASSWORD: password
-            PGDATABASE: postgres
-
     espresso:
         image: ${CARTESI_SDK_IMAGE}
         command: ["espresso-dev-node"]
@@ -21,8 +8,8 @@ services:
                     cpus: "4"
                     memory: "1G"
         depends_on:
-            espresso_database_creator:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
             anvil:
                 condition: service_healthy
         environment:
@@ -35,7 +22,7 @@ services:
             ESPRESSO_SEQUENCER_POSTGRES_PORT: 5432
             ESPRESSO_SEQUENCER_POSTGRES_USER: postgres
             ESPRESSO_SEQUENCER_POSTGRES_PASSWORD: password
-            ESPRESSO_SEQUENCER_POSTGRES_DATABASE: sequencer
+            ESPRESSO_SEQUENCER_POSTGRES_DATABASE: espresso
             ESPRESSO_SEQUENCER_ETH_MNEMONIC: ${CARTESI_AUTH_MNEMONIC:-test test test test test test test test test test test junk}
             ESPRESSO_SEQUENCER_L1_POLLING_INTERVAL: "1s"
             ESPRESSO_STATE_PROVER_UPDATE_INTERVAL: "1s"
@@ -57,19 +44,6 @@ services:
         environment:
             CARTESI_FEATURE_INPUT_READER_ENABLED: false
 
-    espresso_reader_migration:
-        image: ${CARTESI_SDK_IMAGE}
-        command:
-            - migrate
-            - -source
-            - file:///usr/share/cartesi/rollups-espresso-reader/migrations
-            - -database
-            - postgres://postgres:password@database:5432/postgres?sslmode=disable&x-migrations-table=espresso_schema_migrations
-            - up
-        depends_on:
-            rollups-node-migration:
-                condition: service_completed_successfully
-
     espresso_reader:
         image: ${CARTESI_SDK_IMAGE}
         command: ["cartesi-rollups-espresso-reader"]
@@ -78,12 +52,12 @@ services:
         ports:
             - 8081
         depends_on:
-            espresso_reader_migration:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
             espresso:
                 condition: service_healthy
         environment:
-            CARTESI_POSTGRES_ENDPOINT: postgres://postgres:password@database:5432/postgres?sslmode=disable
+            CARTESI_POSTGRES_ENDPOINT: postgres://postgres:password@database:5432/rollupsdb?sslmode=disable
             ESPRESSO_SERVICE_ENDPOINT: ":8081"
             ESPRESSO_BASE_URL: http://espresso:8770
             ESPRESSO_NAMESPACE: 51025

--- a/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-explorer.yaml
@@ -1,17 +1,4 @@
 services:
-    database_creator:
-        image: postgres:16
-        command: ["createdb", "squid"]
-        depends_on:
-            database:
-                condition: service_healthy
-        environment:
-            PGHOST: ${PGHOST:-database}
-            PGPORT: ${PGPORT:-5432}
-            PGUSER: ${PGUSER:-postgres}
-            PGPASSWORD: ${PGPASSWORD:-password}
-            PGDATABASE: ${PGDATABASE:-postgres}
-
     explorer_api:
         image: cartesi/rollups-explorer-api:0.5.0
         environment:
@@ -37,8 +24,8 @@ services:
             timeout: 1s
             retries: 5
         depends_on:
-            database_creator:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
 
     squid_processor:
         image: cartesi/rollups-explorer-api:0.5.0
@@ -52,16 +39,16 @@ services:
             DB_PASS: ${PGPASSWORD:-password}
         command: ["sqd", "process:prod"]
         depends_on:
-            database_creator:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
 
     explorer:
         image: cartesi/rollups-explorer:0.12.0
         expose:
             - 3000
         depends_on:
-            database_creator:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
 
     proxy:
         volumes:

--- a/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-graphql.yaml
@@ -1,35 +1,9 @@
 services:
-    graphql_database_creator:
-        image: postgres:16
-        command: ["createdb", "graphql"]
-        depends_on:
-            database:
-                condition: service_healthy
-        environment:
-            PGHOST: database
-            PGPORT: 5432
-            PGUSER: postgres
-            PGPASSWORD: password
-            PGDATABASE: postgres
-
-    graphql_database_migration:
-        image: ${CARTESI_SDK_IMAGE}
-        command:
-            - migrate
-            - -path
-            - /usr/share/cartesi/rollups-graphql/migrations
-            - -database
-            - postgres://postgres:password@database:5432/graphql?sslmode=disable
-            - up
-        depends_on:
-            graphql_database_creator:
-                condition: service_completed_successfully
-
     graphql:
         image: ${CARTESI_SDK_IMAGE}
         environment:
             POSTGRES_GRAPHQL_DB_URL: postgres://postgres:password@database:5432/graphql?sslmode=disable
-            POSTGRES_NODE_DB_URL: postgres://postgres:password@database:5432/postgres?sslmode=disable
+            POSTGRES_NODE_DB_URL: postgres://postgres:password@database:5432/rollupsdb?sslmode=disable
         expose:
             - 8080
         command: ["cartesi-rollups-graphql"]
@@ -41,8 +15,8 @@ services:
             timeout: 1s
             retries: 5
         depends_on:
-            graphql_database_migration:
-                condition: service_completed_successfully
+            database:
+                condition: service_healthy
 
     proxy:
         volumes:

--- a/apps/cli/src/compose/rollups/docker-compose-node.yaml
+++ b/apps/cli/src/compose/rollups/docker-compose-node.yaml
@@ -1,19 +1,9 @@
 services:
-    rollups-node-migration:
-        image: ${CARTESI_SDK_IMAGE}
-        command: ["cartesi-rollups-cli", "db", "upgrade"]
+    rollups-node:
+        image: cartesi/rollups-runtime:${CARTESI_SDK_VERSION}
         depends_on:
             database:
                 condition: service_healthy
-        restart: "no"
-        env_file:
-            - ${CARTESI_BIN_PATH}/compose/rollups/default.env
-
-    rollups-node:
-        image: ${CARTESI_SDK_IMAGE}
-        depends_on:
-            rollups-node-migration:
-                condition: service_completed_successfully
             anvil:
                 condition: service_healthy
         expose:

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -74,7 +74,8 @@ export class InvalidStringArrayError extends Error {
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
 const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
-export const DEFAULT_SDK = "cartesi/sdk:0.12.0-alpha.11";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.12";
+export const DEFAULT_SDK_IMAGE = `cartesi/sdk:${DEFAULT_SDK_VERSION}`;
 
 type Builder = "directory" | "docker" | "empty" | "none" | "tar";
 type DriveFormat = "ext2" | "sqfs";
@@ -185,7 +186,7 @@ export const defaultMachineConfig = (): MachineConfig => ({
 export const defaultConfig = (): Config => ({
     drives: { root: defaultRootDriveConfig() },
     machine: defaultMachineConfig(),
-    sdk: DEFAULT_SDK,
+    sdk: DEFAULT_SDK_IMAGE,
 });
 
 const parseBoolean = (value: TomlPrimitive, defaultValue: boolean): boolean => {
@@ -483,7 +484,7 @@ export const parse = (str: string): Config => {
     const config: Config = {
         drives: parseDrives(toml.drives),
         machine: parseMachine(toml.machine),
-        sdk: parseString(toml.sdk, DEFAULT_SDK),
+        sdk: parseString(toml.sdk, DEFAULT_SDK_IMAGE),
     };
 
     return config;


### PR DESCRIPTION
When we have the container image releases  from #209 and #204 we can change this PR to adapt to the names defined.

We could even use the `runtime` image to run the rollups-node service in the compose if we want to.