### PR TITLE
Single workflow with target matrix

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -19,11 +19,14 @@ permissions:
     id-token: write
     actions: write
 jobs:
-    build:
+    meta:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                target: ["rollups-database", "rollups-runtime", "sdk"]
+                target:
+                    - rollups-database
+                    - rollups-runtime
+                    - sdk
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,12 +41,31 @@ jobs:
               id: meta
               uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
               with:
+                  bake-target: docker-metadata-${{ matrix.target }}
                   images: |
                       docker.io/cartesi/${{ matrix.target }},enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/cartesi/${{ matrix.target }}
                   tags: |
                       type=raw,value=${{ steps.package-version.outputs.PACKAGE_VERSION }},enable=${{ github.event_name == 'push' }}
                       type=ref,event=pr
+
+            - name: Upload bake definition file
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: docker-metadata-${{ matrix.target }}
+                  path: ${{ steps.meta.outputs.bake-file }}
+
+    build:
+        runs-on: ubuntu-latest
+        needs: meta
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+            - name: Download all docker-metadata artifacts
+              uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+              with:
+                  path: packages/sdk/
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -66,14 +88,19 @@ jobs:
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   workdir: packages/sdk
-                  targets: ${{ matrix.target }}
+                  targets: |
+                      rollups-database
+                      rollups-runtime
+                      sdk
                   files: |
                       ./docker-bake.hcl
                       ./docker-bake.platforms.hcl
-                      ${{ steps.meta.outputs.bake-file }}
+                      ./docker-metadata-sdk/docker-metadata-action-bake.json
+                      ./docker-metadata-rollups-runtime/docker-metadata-action-bake.json
+                      ./docker-metadata-rollups-database/docker-metadata-action-bake.json
                   set: |
-                      *.cache-from=type=registry,ref=ghcr.io/cartesi/sdk-cache:shared
-                      *.cache-to=type=registry,ref=ghcr.io/cartesi/sdk-cache:shared,mode=max
+                      *.cache-from=type=gha
+                      *.cache-to=type=gha,mode=max
                   push: true
 
             - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
@@ -82,10 +109,15 @@ jobs:
               if: ${{ startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
                   project: ${{ vars.DEPOT_PROJECT }}
-                  targets: ${{ matrix.target }}
                   workdir: packages/sdk
+                  targets: |
+                      rollups-database
+                      rollups-runtime
+                      sdk
                   files: |
                       ./docker-bake.hcl
-                      ./docker-bake.platforms.hcl
-                      ${{ steps.meta.outputs.bake-file }}
+                      ./docker-bake.platforms.json
+                      ./docker-metadata-sdk/docker-metadata-action-bake.json
+                      ./docker-metadata-rollups-runtime/docker-metadata-action-bake.json
+                      ./docker-metadata-rollups-database/docker-metadata-action-bake.json
                   push: true

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -1,8 +1,10 @@
-target "docker-metadata-action" {}
+target "docker-metadata-sdk" {}
+target "docker-metadata-rollups-runtime" {}
+target "docker-metadata-rollups-database" {}
 target "docker-platforms" {}
 
 target "default" {
-  inherits = ["docker-metadata-action", "docker-platforms"]
+  inherits = ["docker-platforms"]
   args = {
     ALTO_VERSION                      = "0.0.4"
     CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20250317-slim@sha256:1209d8fd77def86ceb6663deef7956481cc6c14a25e1e64daec12c0ceffcc19d"
@@ -25,7 +27,7 @@ target "default" {
 }
 
 target "sdk"  {
-  inherits = ["default", "docker-metadata-action", "docker-platforms"]
+  inherits = ["default", "docker-metadata-sdk"]
   labels = {
     "org.opencontainers.image.title" = "Cartesi SDK Image"
     "org.opencontainers.image.description" = "Cartesi SDK tools image"
@@ -33,7 +35,7 @@ target "sdk"  {
 }
 
 target "rollups-runtime"  {
-  inherits = ["default", "docker-metadata-action", "docker-platforms"]
+  inherits = ["default", "docker-metadata-rollups-runtime"]
   target = "rollups-runtime"
   labels = {
     "org.opencontainers.image.title" = "Cartesi Rollups Runtime image"
@@ -42,7 +44,7 @@ target "rollups-runtime"  {
 }
 
 target "rollups-database"  {
-  inherits = ["default", "docker-metadata-action", "docker-platforms"]
+  inherits = ["default", "docker-metadata-rollups-database"]
   target = "rollups-database"
   labels = {
     "org.opencontainers.image.title" = "Cartesi SDK Rollups Database image"


### PR DESCRIPTION
This PR uses a single GitHub Actions workflow for all 3 docker images produced by SDK.
First it uses a matrix job with the meta task to generate meta for all 3 images.
Then it uses a single bake action with multiple targets.
This strategy does not need a different docker cache strategy, as bake already provides that.
