### PR TITLE
Bump rollups-contracts

### DIFF
--- a/.changeset/mean-camels-sleep.md
+++ b/.changeset/mean-camels-sleep.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+rollups-contract:2.0.0-rc.17

--- a/packages/devnet/cannonfile.toml
+++ b/packages/devnet/cannonfile.toml
@@ -3,7 +3,7 @@ version = '2.0.0-alpha.4'
 description = 'Cartesi Rollups Devnet'
 
 [pull.cartesiRollups]
-source = "cartesi-rollups:2.0.0-rc.16@main"
+source = "cartesi-rollups:2.0.0-rc.17@main"
 
 [var.Settings]
 token_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"

--- a/packages/devnet/package.json
+++ b/packages/devnet/package.json
@@ -7,7 +7,10 @@
         "build:cannon": "cannon build --write-deployments deployments --anvil.dump-state anvil_state.json",
         "build:forge": "forge build",
         "build:soldeer": "forge soldeer install",
-        "clean": "cannon clean"
+        "clean": "run-s clean:cannon clean:dump clean:forge",
+        "clean:cannon": "cannon clean",
+        "clean:dump": "rm -rf deployments anvil_state.json",
+        "clean:forge": "forge clean"
     },
     "devDependencies": {
         "@usecannon/cli": "^2.21.5",

--- a/packages/devnet/package.json
+++ b/packages/devnet/package.json
@@ -10,7 +10,9 @@
         "clean": "run-s clean:cannon clean:dump clean:forge",
         "clean:cannon": "cannon clean",
         "clean:dump": "rm -rf deployments anvil_state.json",
-        "clean:forge": "forge clean"
+        "clean:forge": "forge clean",
+        "fmt:check": "forge fmt --check",
+        "fmt:write": "forge fmt"
     },
     "devDependencies": {
         "@usecannon/cli": "^2.21.5",

--- a/packages/devnet/src/TestMultiToken.sol
+++ b/packages/devnet/src/TestMultiToken.sol
@@ -12,21 +12,14 @@ contract TestMultiToken is ERC1155, Ownable {
         _setURI(newuri);
     }
 
-    function mint(
-        address account,
-        uint256 id,
-        uint256 amount,
-        bytes memory data
-    ) public onlyOwner {
+    function mint(address account, uint256 id, uint256 amount, bytes memory data) public onlyOwner {
         _mint(account, id, amount, data);
     }
 
-    function mintBatch(
-        address to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
-    ) public onlyOwner {
+    function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
+        public
+        onlyOwner
+    {
         _mintBatch(to, ids, amounts, data);
     }
 }

--- a/packages/devnet/src/TestNFT.sol
+++ b/packages/devnet/src/TestNFT.sol
@@ -7,30 +7,20 @@ import "@openzeppelin-contracts-5.2.0/token/ERC721/extensions/ERC721URIStorage.s
 import "@openzeppelin-contracts-5.2.0/access/Ownable.sol";
 
 contract TestNFT is ERC721, ERC721URIStorage, Ownable {
-    constructor(
-        address initialOwner
-    ) ERC721("TestNFT", "SUNN") Ownable(initialOwner) {}
+    constructor(address initialOwner) ERC721("TestNFT", "SUNN") Ownable(initialOwner) {}
 
-    function safeMint(
-        address to,
-        uint256 tokenId,
-        string memory uri
-    ) public onlyOwner {
+    function safeMint(address to, uint256 tokenId, string memory uri) public onlyOwner {
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
     }
 
     // The following functions are overrides required by Solidity.
 
-    function tokenURI(
-        uint256 tokenId
-    ) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
         return super.tokenURI(tokenId);
     }
 
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view override(ERC721, ERC721URIStorage) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721URIStorage) returns (bool) {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/packages/devnet/src/TestToken.sol
+++ b/packages/devnet/src/TestToken.sol
@@ -7,16 +7,8 @@ import "@openzeppelin-contracts-5.2.0/token/ERC20/extensions/ERC20Pausable.sol";
 import "@openzeppelin-contracts-5.2.0/access/manager/AccessManaged.sol";
 import "@openzeppelin-contracts-5.2.0/token/ERC20/extensions/ERC20Permit.sol";
 
-contract TestToken is
-    ERC20,
-    ERC20Burnable,
-    ERC20Pausable,
-    AccessManaged,
-    ERC20Permit
-{
-    constructor(
-        address initialAuthority
-    )
+contract TestToken is ERC20, ERC20Burnable, ERC20Pausable, AccessManaged, ERC20Permit {
+    constructor(address initialAuthority)
         ERC20("TestToken", "TEST")
         AccessManaged(initialAuthority)
         ERC20Permit("TestToken")
@@ -34,11 +26,7 @@ contract TestToken is
 
     // The following functions are overrides required by Solidity.
 
-    function _update(
-        address from,
-        address to,
-        uint256 value
-    ) internal override(ERC20, ERC20Pausable) {
+    function _update(address from, address to, uint256 value) internal override(ERC20, ERC20Pausable) {
         super._update(from, to, value);
     }
 }


### PR DESCRIPTION
Bump rollups contracts to 2.0.0-rc.17.

Also formats solidity code according to `forge fmt`