### PR TITLE
feat(sdk): bump PostgreSQL to v17

### DIFF
--- a/.changeset/spicy-pillows-bow.md
+++ b/.changeset/spicy-pillows-bow.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+bump PostgreSQL to v17

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -20,7 +20,7 @@ target "default" {
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20241120-patch6@sha256:453264eab19e3313c85a8720c784f16f15e36bacb28ae917034e24342cecf3c3"
     FOUNDRY_VERSION                   = "0.3.0"
     GO_MIGRATE_VERSION                = "4.18.2"
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:16@sha256:e95b0cb95f719e0ce156c2bc5545c89fbd98a1a692845a5331ddc79ea61f1b1e"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17@sha256:7f29c02ba9eeff4de9a9f414d803faa0e6fe5e8d15ebe217e3e418c82e652b35"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }


### PR DESCRIPTION
cartesi/rollups-node starts using PostgreSQL v17 at https://github.com/cartesi/rollups-node/commit/b89ddeb0aca87883217861d91a4f87ddbadf9963

This pull request includes an update to the `POSTGRES_BASE_IMAGE` version in the `packages/sdk/docker-bake.hcl` file. The change updates the Postgres base image from version 16 to version 17.

* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL23-R23): Updated `POSTGRES_BASE_IMAGE` from version 16 to version 17.