### PR TITLE
chore(sdk): move migration code to cartesi/rollups-runtime

### DIFF
--- a/.changeset/great-pens-report.md
+++ b/.changeset/great-pens-report.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+use differente table to control espresso-reader migrations to avoid conflict with rollups-node migrations

--- a/.changeset/small-coats-allow.md
+++ b/.changeset/small-coats-allow.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+move migration to rollups-runtime

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -178,6 +178,9 @@ EOF
 
 COPY --from=graphql /usr/local/bin/cartesi-rollups-graphql /usr/local/bin/
 COPY --from=espresso-reader /usr/local/bin/cartesi-rollups-espresso-reader /usr/local/bin/
+COPY --from=go-migrate /usr/local/bin/migrate /usr/local/bin/
+COPY --from=graphql-migration /usr/share/cartesi/rollups-graphql/migrations /usr/share/cartesi/rollups-graphql/migrations
+COPY --from=espresso-reader-migration /usr/share/cartesi/rollups-espresso-reader/migrations /usr/share/cartesi/rollups-espresso-reader/migrations
 
 USER cartesi
 
@@ -340,9 +343,6 @@ COPY --from=crane /usr/local/bin/crane /usr/local/bin/
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/
 COPY --from=espresso-dev-node /usr/bin/espresso-dev-node /usr/local/bin/
-COPY --from=go-migrate /usr/local/bin/migrate /usr/local/bin/
-COPY --from=graphql-migration /usr/share/cartesi/rollups-graphql/migrations /usr/share/cartesi/rollups-graphql/migrations
-COPY --from=espresso-reader-migration /usr/share/cartesi/rollups-espresso-reader/migrations /usr/share/cartesi/rollups-espresso-reader/migrations
 
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -231,7 +231,7 @@ EOF
 COPY <<EOF /docker-entrypoint-initdb.d/03-espresso-reader-migrations.sh
 #!/usr/bin/env bash
 set -e
-migrate -verbose -path /usr/share/cartesi/rollups-espresso-reader/migrations -database 'postgres://postgres@/rollupsdb?host=/var/run/postgresql' up
+migrate -verbose -path /usr/share/cartesi/rollups-espresso-reader/migrations -database 'postgres://postgres@/rollupsdb?host=/var/run/postgresql&x-migrations-table=espresso_reader_schema_migrations' up
 EOF
 
 RUN /usr/local/bin/docker-ensure-initdb.sh postgres


### PR DESCRIPTION
This pull request includes several changes to the Cartesi SDK, primarily focusing on migration management and Dockerfile adjustments. The most important changes include the introduction of separate migration tables for the espresso-reader, the relocation of migrations to rollups-runtime, and updates to the Dockerfile to reflect these changes.

The objective is that people can use the `cartesi/rollups-runtime` image to run a node and use the migration script on an existing database or when `cartesi/rollups-database` won't be used.

Migration management improvements:

* [`.changeset/great-pens-report.md`](diffhunk://#diff-b205e52968d64ed55d15389931805518ed4a4020e543e3d483e0ed09bcd105a2R1-R5): Introduced a separate table to control espresso-reader migrations to avoid conflicts with rollups-node migrations.
* [`.changeset/small-coats-allow.md`](diffhunk://#diff-04d622dc80fa931d80a7a5cc58636c7d8880de1b4048665152b3c6cc13e3e64bR1-R5): Moved migration processes to rollups-runtime.

Dockerfile updates:

* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR181-R183): Added new COPY commands to include migration binaries and scripts for the espresso-reader and graphql migrations.
* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL231-R234): Updated the espresso-reader migration script to use the new migration table.
* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL343-L345): Removed redundant COPY commands that were previously added.