### PR TITLE
chore(sdk): bump rollups-node to v2.0.0-alpha.3

### DIFF
--- a/.changeset/thick-coats-grow.md
+++ b/.changeset/thick-coats-grow.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump rollups-node to v2.0.0-alpha.3

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -217,7 +217,7 @@ COPY <<EOF /docker-entrypoint-initdb.d/01-rollups-node-migrations.sh
 #!/usr/bin/env bash
 set -e
 export CARTESI_DATABASE_CONNECTION="postgres://postgres@/rollupsdb?host=/var/run/postgresql"
-cartesi-rollups-cli db upgrade --verbose
+cartesi-rollups-cli db init --upgrade --verbose
 EOF
 
 # rollups-graphql migrations

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -15,7 +15,7 @@ target "default" {
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.19.0-alpha3"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.11-node-20250128"
-    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.2"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.3"
     CRANE_VERSION                     = "0.19.1"
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20241120-patch6@sha256:453264eab19e3313c85a8720c784f16f15e36bacb28ae917034e24342cecf3c3"
     FOUNDRY_VERSION                   = "1.0.0"


### PR DESCRIPTION
This pull request includes updates to the `@cartesi/sdk` package and related configuration files to support the latest version of rollups-node.

Version updates:

* [`.changeset/thick-coats-grow.md`](diffhunk://#diff-a4417040bdf0753d06a58adf9552317367e08a7c8679b8b736815883d0c2badeR1-R5): Updated the rollups-node version to `v2.0.0-alpha.3` and marked it as a patch update for `@cartesi/sdk`.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL18-R18): Updated the `CARTESI_ROLLUPS_NODE_VERSION` to `2.0.0-alpha.3` in the docker-bake configuration.

Configuration changes:

* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL220-R220): Modified the database initialization command to use `cartesi-rollups-cli db init --upgrade --verbose` instead of `cartesi-rollups-cli db upgrade --verbose`.