### PR TITLE
feat(cli): add rollups create command

### DIFF
--- a/.changeset/fresh-coats-know.md
+++ b/.changeset/fresh-coats-know.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+DEPRECATED: cartesi create

--- a/.changeset/poor-tips-happen.md
+++ b/.changeset/poor-tips-happen.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": major
+---
+
+new: cartesi rollups create

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -1,68 +1,14 @@
-import { Command, Option } from "@commander-js/extra-typings";
+import { Command } from "@commander-js/extra-typings";
 import chalk from "chalk";
-import type { TemplateProvider } from "giget";
-import { DownloadTemplateResult, downloadTemplate } from "giget";
-import ora from "ora";
-
-export const DEFAULT_TEMPLATES_BRANCH = "prerelease/sdk-12";
-
-const TEMPLATES = [
-    "cpp",
-    "cpp-low-level",
-    "go",
-    "javascript",
-    "lua",
-    "python",
-    "ruby",
-    "rust",
-    "typescript",
-] as const;
-
-const download = async (
-    template: string,
-    branch: string,
-    out: string,
-): Promise<DownloadTemplateResult> => {
-    const cartesiProvider: TemplateProvider = async (input) => {
-        return {
-            name: "cartesi",
-            subdir: input,
-            url: "https://github.com/cartesi/application-templates",
-            tar: `https://codeload.github.com/cartesi/application-templates/tar.gz/refs/heads/${branch}`,
-        };
-    };
-
-    const input = `cartesi:${template}`;
-    return downloadTemplate(input, {
-        dir: out,
-        providers: { cartesi: cartesiProvider },
-    });
-};
 
 export const createCreateCommand = () => {
     return new Command("create")
-        .argument("<name>", "application and directory name")
-        .addOption(
-            new Option("-t, --template <template>", "template name to use")
-                .choices(TEMPLATES)
-                .makeOptionMandatory(),
-        )
-        .option(
-            "-b, --branch <branch>",
-            "cartesi/application-templates repository branch name to use",
-            DEFAULT_TEMPLATES_BRANCH,
-        )
-        .action(async (name, { branch, template }) => {
-            const spinner = ora("Creating application...").start();
-            try {
-                const { dir } = await download(template, branch, name);
-                spinner.succeed(`Application created at ${chalk.cyan(dir)}`);
-            } catch (e: unknown) {
-                spinner.fail(
-                    e instanceof Error
-                        ? `Error creating application: ${chalk.red(e.message)}`
-                        : String(e),
-                );
-            }
+        .summary("DEPRECATED: use 'rollups create' instead")
+        .action(async () => {
+            console.warn(
+                chalk.yellow(
+                    "create command is deprecated, use 'rollups create' instead",
+                ),
+            );
         });
 };

--- a/apps/cli/src/commands/rollups.ts
+++ b/apps/cli/src/commands/rollups.ts
@@ -1,4 +1,5 @@
 import { Command } from "@commander-js/extra-typings";
+import { createCreateCommand } from "./rollups/create.js";
 import { createDeployCommand } from "./rollups/deploy.js";
 import { createLogsCommand } from "./rollups/logs.js";
 import { createStartCommand } from "./rollups/start.js";
@@ -20,6 +21,7 @@ export const createRollupsCommand = () => {
     command.addCommand(createStatusCommand());
     command.addCommand(createStopCommand());
     command.addCommand(createDeployCommand());
+    command.addCommand(createCreateCommand());
     return command;
 };
 

--- a/apps/cli/src/commands/rollups/create.ts
+++ b/apps/cli/src/commands/rollups/create.ts
@@ -1,0 +1,51 @@
+import { Command, Option } from "@commander-js/extra-typings";
+import chalk from "chalk";
+import ora from "ora";
+import { download } from "../../template.js";
+
+export const DEFAULT_TEMPLATES_BRANCH = "prerelease/sdk-12";
+
+const TEMPLATES = [
+    "cpp",
+    "cpp-low-level",
+    "go",
+    "javascript",
+    "lua",
+    "python",
+    "ruby",
+    "rust",
+    "typescript",
+] as const;
+
+export const createCreateCommand = () => {
+    return new Command("create")
+        .argument("<name>", "application and directory name")
+        .addOption(
+            new Option("-t, --template <template>", "template name to use")
+                .choices(TEMPLATES)
+                .makeOptionMandatory(),
+        )
+        .option(
+            "-b, --branch <branch>",
+            "cartesi/application-templates repository branch name to use",
+            DEFAULT_TEMPLATES_BRANCH,
+        )
+        .action(async (name, { branch, template }) => {
+            const spinner = ora("Creating application...").start();
+            try {
+                const { dir } = await download(
+                    "rollups",
+                    template,
+                    branch,
+                    name,
+                );
+                spinner.succeed(`Application created at ${chalk.cyan(dir)}`);
+            } catch (e: unknown) {
+                spinner.fail(
+                    e instanceof Error
+                        ? `Error creating application: ${chalk.red(e.message)}`
+                        : String(e),
+                );
+            }
+        });
+};

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -1,0 +1,24 @@
+import type { TemplateProvider } from "giget";
+import { DownloadTemplateResult, downloadTemplate } from "giget";
+
+export const download = async (
+    framework: string,
+    template: string,
+    branch: string,
+    out: string,
+): Promise<DownloadTemplateResult> => {
+    const cartesiProvider: TemplateProvider = async (input) => {
+        return {
+            name: "cartesi",
+            subdir: `${framework}/${input}`,
+            url: "https://github.com/cartesi/application-templates",
+            tar: `https://codeload.github.com/cartesi/application-templates/tar.gz/refs/heads/${branch}`,
+        };
+    };
+
+    const input = `cartesi:${template}`;
+    return downloadTemplate(input, {
+        dir: out,
+        providers: { cartesi: cartesiProvider },
+    });
+};


### PR DESCRIPTION
**DEPENDS ON**: https://github.com/cartesi/application-templates/pull/55

This pull request refactors the `create` command in the CLI application by deprecating the old command and moving its functionality to a new `rollups` subcommand. The changes also involve code reorganization and the introduction of a shared template download utility.

### Deprecation and Redirection:

* [`apps/cli/src/commands/create.ts`](diffhunk://#diff-a1a323fb8e300712549a10f0f229751c515addc78f8c7aba9a25b859979d0e35L1-L66): Deprecated the `create` command and added a message to use the `rollups create` command instead.

### Code Reorganization:

* [`apps/cli/src/commands/rollups.ts`](diffhunk://#diff-80097fefc8e53332fb6f698a786de8395cdc59d950386686217823f1391f48cfR2): Imported the new `createCreateCommand` and added it to the `rollups` command. [[1]](diffhunk://#diff-80097fefc8e53332fb6f698a786de8395cdc59d950386686217823f1391f48cfR2) [[2]](diffhunk://#diff-80097fefc8e53332fb6f698a786de8395cdc59d950386686217823f1391f48cfR24)
* [`apps/cli/src/commands/rollups/create.ts`](diffhunk://#diff-ce4f693cd7d19a106742365327ce1b3570c9b29b51d8f59857d804a6c422ed45R1-R51): Created a new `createCreateCommand` with the same functionality as the deprecated `create` command.

### Shared Utility:

* [`apps/cli/src/template.ts`](diffhunk://#diff-4c02b64c435a52718e7df4391e94adb469e7216bd9ac61ee107968bbe049937bR1-R24): Introduced a shared `download` function to handle template downloads, which is now used by the new `createCreateCommand`.