### PR TITLE
chore(sdk): bump cartesi-rollups-graphql to v2.3.13

### DIFF
--- a/.changeset/modern-otters-flow.md
+++ b/.changeset/modern-otters-flow.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump cartesi-rollups-graphql to v2.3.13

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -84,8 +84,18 @@ FROM base AS graphql
 ARG CARTESI_ROLLUPS_GRAPHQL_VERSION
 ARG TARGETOS
 ARG TARGETARCH
-RUN curl -fsSL https://github.com/cartesi/rollups-graphql/releases/download/v${CARTESI_ROLLUPS_GRAPHQL_VERSION}/cartesi-rollups-graphql-v${CARTESI_ROLLUPS_GRAPHQL_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz \
-    | tar -xzf - -C /usr/local/bin
+RUN <<EOF
+curl -fsSL https://github.com/cartesi/rollups-graphql/releases/download/v${CARTESI_ROLLUPS_GRAPHQL_VERSION}/cartesi-rollups-graphql-v${CARTESI_ROLLUPS_GRAPHQL_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz \
+    -o /tmp/cartesi-rollups-graphql.tar.gz
+
+case "${TARGETARCH}" in
+    amd64) echo "0882a1c7a608ae6e1631ab9b3a04d531  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
+    arm64) echo "759e7edc97ad39908fef56c3bd971a9b  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
+    *) echo "unsupported architecture: ${TARGEARCH}"; exit 1 ;;
+esac
+
+tar -xzf /tmp/cartesi-rollups-graphql.tar.gz -C /usr/local/bin
+EOF
 
 ################################################################################
 # cartesi-rollups-graphql migration code installer

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -14,7 +14,7 @@ target "default" {
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.19.0-alpha3"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
-    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.11-node-20250128"
+    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.13"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.4"
     CRANE_VERSION                     = "0.19.1"
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20241120-patch6@sha256:453264eab19e3313c85a8720c784f16f15e36bacb28ae917034e24342cecf3c3"


### PR DESCRIPTION
This pull request includes updates to the Cartesi SDK, specifically focusing on upgrading the `cartesi-rollups-graphql` version and improving the Dockerfile for better security and compatibility. The most important changes include updating the version of `cartesi-rollups-graphql` used, adding checksum validation for the downloaded files, and modifying the Dockerfile to handle different architectures.

Version updates:

* [`.changeset/modern-otters-flow.md`](diffhunk://#diff-9d40110f0b1cd3ce8b6b282583012f9316cc27de5595800f83cf0dc658519e63R1-R5): Bumped `cartesi-rollups-graphql` to version `2.3.13`.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL17-R17): Updated `CARTESI_ROLLUPS_GRAPHQL_VERSION` to `2.3.13`.

Security and compatibility improvements:

* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL87-R98): Added checksum validation for the `cartesi-rollups-graphql` download and modified the Dockerfile to handle different architectures (`amd64` and `arm64`).