### PR TITLE
chore(sdk): bump rollups-node to 2.0.0-alpha.4

### DIFF
--- a/.changeset/cool-panthers-itch.md
+++ b/.changeset/cool-panthers-itch.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump rollups-node to 2.0.0-alpha.4

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -15,7 +15,7 @@ target "default" {
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.19.0-alpha3"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.11-node-20250128"
-    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.3"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.4"
     CRANE_VERSION                     = "0.19.1"
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20241120-patch6@sha256:453264eab19e3313c85a8720c784f16f15e36bacb28ae917034e24342cecf3c3"
     FOUNDRY_VERSION                   = "1.0.0"


### PR DESCRIPTION
This pull request includes updates to the Cartesi SDK and related configurations to ensure compatibility with the latest version of the rollups-node.

Version updates:

* [`.changeset/cool-panthers-itch.md`](diffhunk://#diff-cc84746bdc0bff8adeac906595c5a49dcfe2b7d2d300c729404d25ff8df64182R1-R5): Updated the changeset to reflect the version bump of `@cartesi/sdk` to `2.0.0-alpha.4`.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL18-R18): Updated the `CARTESI_ROLLUPS_NODE_VERSION` to `2.0.0-alpha.4` to match the new SDK version.