### PR TITLE
Add ERC-4337 from cannon

### DIFF
--- a/.changeset/old-tires-rhyme.md
+++ b/.changeset/old-tires-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+add ERC-4337 contracts from cannon

--- a/packages/devnet/cannonfile.toml
+++ b/packages/devnet/cannonfile.toml
@@ -5,6 +5,27 @@ description = 'Cartesi Rollups Devnet'
 [pull.cartesiRollups]
 source = "cartesi-rollups:2.0.0-rc.17@main"
 
+[pull.entrypointSimulations]
+source = "pimlico-entrypoint-simulations:0.7.0@main"
+
+[pull.zerodevKernel30]
+source = "zerodev-kernel:3.0@main"
+
+[pull.zerodevKernel31]
+source = "zerodev-kernel:3.1@main"
+
+[pull.zerodevKernel32]
+source = "zerodev-kernel:3.2@main"
+
+[pull.alchemyLightAccountV1]
+source = "alchemy-light-account:1.1.0@main"
+
+[pull.alchemyLightAccountV2]
+source = "alchemy-light-account:2.0.0@main"
+
+[pull.alchemyModularAccountV2]
+source = "alchemy-modular-account:2.0.0@main"
+
 [var.Settings]
 token_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 


### PR DESCRIPTION
Adds all ERC-4337 smart contracts published to cannon to the devnet.
Based on the work from http://github.com/cartesi/erc-4337-devnet/