### PR TITLE
Reintroduce ERC-4337 contracts to sdk

### DIFF
--- a/.changeset/green-masks-accept.md
+++ b/.changeset/green-masks-accept.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+sort smart contract list by name

--- a/.changeset/nine-stars-cut.md
+++ b/.changeset/nine-stars-cut.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump devnet to 2.0.0-alpha.6

--- a/packages/sdk/devnet
+++ b/packages/sdk/devnet
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-jq -rs '.[] | "\(.address) \(.contractName)"' /usr/share/cartesi/deployments/*.json
+jq -rs '. | map({contractName,address}) | unique_by(.address) | sort_by(.contractName) | .[] | "\(.address) \(.contractName)"' /usr/share/cartesi/deployments/*.json
 exec anvil --chain-id 13370 --load-state /usr/share/cartesi/anvil_state.json "$@"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -8,7 +8,7 @@ target "default" {
   args = {
     ALTO_VERSION                      = "0.0.4"
     CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20250428-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d"
-    CARTESI_DEVNET_VERSION            = "2.0.0-alpha.5"
+    CARTESI_DEVNET_VERSION            = "2.0.0-alpha.6"
     CARTESI_ESPRESSO_READER_VERSION   = "0.2.3-node-20250128"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"


### PR DESCRIPTION
This bumps devnet to new alpha that reintroduces ERC-4337 contracts