### PR TITLE
chore(sdk): bump cartesi-rollups-graphql to v2.3.14

### DIFF
--- a/.changeset/beige-kids-eat.md
+++ b/.changeset/beige-kids-eat.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump cartesi-rollups-graphql to v2.3.14

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -89,8 +89,8 @@ curl -fsSL https://github.com/cartesi/rollups-graphql/releases/download/v${CARTE
     -o /tmp/cartesi-rollups-graphql.tar.gz
 
 case "${TARGETARCH}" in
-    amd64) echo "0882a1c7a608ae6e1631ab9b3a04d531  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
-    arm64) echo "759e7edc97ad39908fef56c3bd971a9b  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
+    amd64) echo "b1b27069956c379e29d5668504bb02db  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
+    arm64) echo "ca41f76ab2e6c1a8b15ac0c1ab96e951  /tmp/cartesi-rollups-graphql.tar.gz" | md5sum --check ;;
     *) echo "unsupported architecture: ${TARGEARCH}"; exit 1 ;;
 esac
 

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -14,7 +14,7 @@ target "default" {
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.19.0-alpha3"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
-    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.13"
+    CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.14"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.4"
     CRANE_VERSION                     = "0.19.1"
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20241120-patch6@sha256:453264eab19e3313c85a8720c784f16f15e36bacb28ae917034e24342cecf3c3"


### PR DESCRIPTION
This pull request updates the `@cartesi/sdk` package to use the latest version of `cartesi-rollups-graphql` (v2.3.14). The changes ensure compatibility with the new version by updating relevant version references and checksum values.

### Dependency Updates:
* [`.changeset/beige-kids-eat.md`](diffhunk://#diff-fc81fe144494dd1184ea96d12d32d273cdb6550c2ec24738f19a24f03c5f2705R1-R5): Added a patch release note for bumping `cartesi-rollups-graphql` to v2.3.14.
* [`packages/sdk/docker-bake.hcl`](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL17-R17): Updated `CARTESI_ROLLUPS_GRAPHQL_VERSION` from `2.3.13` to `2.3.14`.

### Checksum Updates:
* [`packages/sdk/Dockerfile`](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL92-R93): Updated the MD5 checksum values for `amd64` and `arm64` architectures to match the new version of `cartesi-rollups-graphql`.