### PR TITLE
Fix/ext2 test size

### DIFF
--- a/apps/cli/tests/integration/builder/docker.test.ts
+++ b/apps/cli/tests/integration/builder/docker.test.ts
@@ -65,7 +65,7 @@ describe("when building with the docker builder", () => {
             await build("root", drive, image, destination);
             const filename = path.join(destination, "root.ext2");
             const stat = fs.statSync(filename);
-            expect(stat.size).toEqual(76079104);
+            expect(stat.size).toEqual(85917696);
         },
     );
 
@@ -84,7 +84,7 @@ describe("when building with the docker builder", () => {
         await build("root", drive, image, destination);
         const filename = path.join(destination, "root.ext2");
         const stat = fs.statSync(filename);
-        expect(stat.size).toEqual(76079104);
+        expect(stat.size).toEqual(85917696);
     });
 
     tmpdirTest.skip("should build a sqfs drive", async ({ tmpdir }) => {

--- a/apps/cli/tests/integration/builder/fixtures/Dockerfile
+++ b/apps/cli/tests/integration/builder/fixtures/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=linux/riscv64 ubuntu:22.04 AS test
+FROM --platform=linux/riscv64 ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233 AS test
 ADD ./file2 .
 
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM --platform=linux/riscv64 ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233
 ADD ./file1 .


### PR DESCRIPTION
This pull request includes updates to test expectations and Dockerfile configurations to align with changes in the base image and generated file sizes. The most important changes involve updating the Dockerfile to use a newer Ubuntu base image and adjusting test assertions for file size expectations.

### Updates to Dockerfile:

* [`apps/cli/tests/integration/builder/fixtures/Dockerfile`](diffhunk://#diff-a297da6c4fe40d94c3c1f2794f9fe1f5a8a213a15196f236d6aa93f07d11a9d8L1-R4): Updated the base image from `ubuntu:22.04` to `ubuntu:24.04` with a specific digest (`sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233`) to ensure reproducibility.

### Updates to test assertions:

* [`apps/cli/tests/integration/builder/docker.test.ts`](diffhunk://#diff-5d75d06336c4284d2107d014491b472aeaee5874632f4d1ba51f19002f262999L68-R68): Updated expected file size in two test cases to reflect changes in the generated file size, increasing from `76079104` to `85917696`. [[1]](diffhunk://#diff-5d75d06336c4284d2107d014491b472aeaee5874632f4d1ba51f19002f262999L68-R68) [[2]](diffhunk://#diff-5d75d06336c4284d2107d014491b472aeaee5874632f4d1ba51f19002f262999L87-R87)