### PR TITLE
Bump alto

### DIFF
--- a/.changeset/cyan-kiwis-cut.md
+++ b/.changeset/cyan-kiwis-cut.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump alto

--- a/.changeset/mighty-knives-join.md
+++ b/.changeset/mighty-knives-join.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump alto

--- a/apps/cli/src/compose/docker-compose-bundler.yaml
+++ b/apps/cli/src/compose/docker-compose-bundler.yaml
@@ -7,8 +7,6 @@ services:
             - "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789,0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             - "--log-level"
             - "info"
-            - "--entrypoint-simulation-contract"
-            - "0x74Cb5e4eE81b86e70f9045036a1C5477de69eE87"
             - "--rpc-url"
             - "http://anvil:8545"
             - "--min-executor-balance"
@@ -17,8 +15,6 @@ services:
             - "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
             - "--executor-private-keys"
             - "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6,0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356,0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e,0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba,0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
-            - "--max-block-range"
-            - "10000"
             - "--safe-mode"
             - "false"
             - "--port"
@@ -27,8 +23,6 @@ services:
             - "error"
             - "--wallet-client-log-level"
             - "error"
-            - "--polling-interval"
-            - "100"
             - "--enable-debug-endpoints"
         healthcheck:
             test: ["CMD", "curl", "-fsS", "http://127.0.0.1:4337/health"]

--- a/apps/cli/src/compose/proxy/bundler.yaml
+++ b/apps/cli/src/compose/proxy/bundler.yaml
@@ -3,9 +3,21 @@ http:
         bundler:
             rule: "PathPrefix(`/bundler`)"
             middlewares:
+                - "cors"
                 - "remove-bundler-prefix"
             service: bundler
     middlewares:
+        cors:
+            headers:
+                accessControlAllowMethods:
+                    - GET
+                    - OPTIONS
+                    - PUT
+                accessControlAllowHeaders: "*"
+                accessControlAllowOriginList:
+                    - "*"
+                accessControlMaxAge: 100
+                addVaryHeader: true
         remove-bundler-prefix:
             replacePathRegex:
                 regex: "^/bundler/(.*)"

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -2,6 +2,7 @@
 ARG CARTESI_BASE_IMAGE
 ARG ESPRESSO_DEV_NODE_BASE_IMAGE
 ARG POSTGRES_BASE_IMAGE
+ARG NODE_VERSION
 
 ################################################################################
 # https://github.com/EspressoSystems/espresso-sequencer/pkgs/container/espresso-sequencer%2Fespresso-dev-node
@@ -262,9 +263,37 @@ FROM ${POSTGRES_BASE_IMAGE} AS rollups-database
 COPY --from=postgresql-initdb /var/lib/postgresql/data /var/lib/postgresql/data
 
 ################################################################################
+# alto build
+FROM node:${NODE_VERSION} AS alto
+ARG ALTO_VERSION
+ARG NODE_VERSION
+ARG FOUNDRY_VERSION
+ARG TARGETARCH
+ARG TARGETOS
+
+# install foundry, necessary for building alto
+RUN curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz \
+    | tar -zx -C /usr/local/bin
+
+WORKDIR /app
+COPY alto.patch /app/alto.patch
+
+RUN <<EOF
+npm install -g pnpm
+git clone --branch v${ALTO_VERSION} --depth 1 --recurse-submodules https://github.com/pimlicolabs/alto.git
+cd alto
+patch -p1 < /app/alto.patch
+pnpm install
+pnpm run build:contracts
+pnpm run build
+cd src && pnpm pack # produces pimlico-alto-${ALTO_PACKAGE_VERSION}.tgz
+EOF
+
+################################################################################
 # sdk final image
 FROM rollups-runtime
 ARG ALTO_VERSION
+ARG ALTO_PACKAGE_VERSION
 ARG CARTESI_DEVNET_VERSION
 ARG CARTESI_IMAGE_KERNEL_VERSION
 ARG CARTESI_LINUX_KERNEL_VERSION
@@ -328,13 +357,15 @@ xgenext2fs --version
 EOF
 
 # Install nodejs packages
+COPY --from=alto /app/alto/src/pimlico-alto-${ALTO_PACKAGE_VERSION}.tgz /tmp/pimlico-alto.tgz
 RUN <<EOF
 npm install -g \
     @cartesi/devnet@${CARTESI_DEVNET_VERSION} \
     @cartesi/mock-verifying-paymaster@${CARTESI_PAYMASTER_VERSION} \
     @cartesi/passkey-server@${CARTESI_PASSKEY_SERVER_VERSION} \
-    @pimlico/alto@${ALTO_VERSION}
+    /tmp/pimlico-alto.tgz
 
+rm /tmp/pimlico-alto.tgz
 mkdir -p /usr/share/cartesi
 cp -r "$(npm root -g)/@cartesi/devnet/deployments" /usr/share/cartesi/
 cp "$(npm root -g)/@cartesi/devnet/anvil_state.json" /usr/share/cartesi/

--- a/packages/sdk/alto
+++ b/packages/sdk/alto
@@ -1,2 +1,2 @@
 #!/bin/sh
-node "$(npm root -g)/@pimlico/alto/esm/cli/index.js" $@
+node "$(npm root -g)/@pimlico/alto/lib/cli/alto.js" $@

--- a/packages/sdk/alto.patch
+++ b/packages/sdk/alto.patch
@@ -1,0 +1,28 @@
+From a099789dc4175cf90b6ca60f6e57b01d24fb1373 Mon Sep 17 00:00:00 2001
+From: Danilo Tuler <tuler@pobox.com>
+Date: Thu, 22 May 2025 14:05:21 -0400
+Subject: [PATCH] fixing package to include missing contract jsons
+
+---
+ src/package.json | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/package.json b/src/package.json
+index 9020c26..ef37f87 100644
+--- a/src/package.json
++++ b/src/package.json
+@@ -14,9 +14,11 @@
+         "esm/**/*.d.ts",
+         "esm/**/*.js",
+         "esm/**/*.js.map",
++        "esm/**/*.json",
+         "lib/**/*.d.ts",
+         "lib/**/*.js",
+         "lib/**/*.js.map",
++        "lib/**/*.json",
+         "contracts/**/*",
+         "*.d.ts",
+         "*.js"
+-- 
+2.48.1
+

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -6,7 +6,8 @@ target "docker-platforms" {}
 target "default" {
   inherits = ["docker-platforms"]
   args = {
-    ALTO_VERSION                      = "0.0.4"
+    ALTO_VERSION                      = "1.2.5"
+    ALTO_PACKAGE_VERSION              = "0.0.18"
     CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20250428-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.6"
     CARTESI_ESPRESSO_READER_VERSION   = "0.3.0"


### PR DESCRIPTION
This PR bumps alto version.
The [alto](https://github.com/pimlicolabs/alto) project is undergoing a change in their versioning scheme.
There is a `1.2.5` version which is a docker image published by their CI to GitHub.
And a `0.0.18` npm package version published to npmjs.

Currently the 1.2.5 version is ahead of the 0.0.18 version.
They will work on unifying this, and 1.x.y is the one which will stay.

So what I did was to clone the repo tag in a stage of our Dockefile and build from source the npm package.
And then install it.

They also removed support for CORS, as mentioned in [this message](https://github.com/pimlicolabs/alto/pull/425#issuecomment-2714527043), suggesting we use traefik to handle it.

Also, there is a bug in their packaging process. I opened a PR [upstream](https://github.com/pimlicolabs/alto/pull/530), and included a patch in our build process.

After build, test with
```
docker run cartesi/sdk:devel alto --help
```
