### PR TITLE
feat(cli): send generic eip-712 transaction

### DIFF
--- a/apps/cli/src/commands/send/eip712.ts
+++ b/apps/cli/src/commands/send/eip712.ts
@@ -1,0 +1,128 @@
+import { Hex, WalletClient } from "viem";
+import { Address } from "viem/accounts";
+
+type SendOptions = {
+    eip712TxUrl: string;
+    chainId: number;
+    maxGasPrice: number;
+};
+
+export const DEFAULT_SEND_CONFIG: Readonly<SendOptions> = {
+    eip712TxUrl: "http://localhost:8080/transaction",
+    chainId: 31337,
+    maxGasPrice: 10,
+} as const;
+
+type TypedData = {
+    domain: {
+        name: string;
+        version: string;
+        chainId: number;
+        verifyingContract: Address;
+    };
+    types: Record<string, { name: string; type: string }[]>;
+    primaryType: string;
+    message: Record<string, unknown>;
+};
+
+const fetchJSON = async <T>(url: string, options: RequestInit): Promise<T> => {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        throw new Error(`HTTP Error: ${response.status} - ${await response.text()}`);
+    }
+    return response.json();
+};
+
+const serializeBigInt = (_key: string, value: unknown): unknown =>
+    typeof value === "bigint" ? value.toString() : value;
+
+
+const createTypedDataTemplate = (chainId: number, verifyingContract: Address): TypedData => ({
+    domain: {
+        name: "Cartesi",
+        version: "0.1.0",
+        chainId,
+        verifyingContract,
+    },
+    types: {
+        EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "version", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" },
+        ],
+        CartesiMessage: [
+            { name: "app", type: "address" },
+            { name: "nonce", type: "uint64" },
+            { name: "max_gas_price", type: "uint128" },
+            { name: "data", type: "bytes" },
+        ],
+    },
+    primaryType: "CartesiMessage",
+    message: {},
+});
+
+/** Fetches the nonce for a given user and application */
+export const getNonceForEip712 = async (
+    application: Address,
+    user: Address,
+    sendOptions: SendOptions
+): Promise<number> => {
+    return fetchJSON<{ nonce: number }>(`${sendOptions.eip712TxUrl}/nonce`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ msg_sender: user, app_contract: application }),
+    }).then((res) => res.nonce);
+};
+
+/** Submits a transaction to L2 */
+export const postEip712Transaction = async (
+    data: Record<string, unknown>,
+    sendOptions: SendOptions
+): Promise<{ id: string }> => {
+    return fetchJSON<{ id: string }>(`${sendOptions.eip712TxUrl}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data, serializeBigInt),
+    });
+};
+
+/** Creates a Typed Data object for signing */
+export const createEip712TypedData = async (
+    app: Address,
+    data: Hex,
+    nonce: number,
+    sendOptions: SendOptions
+): Promise<TypedData> => {
+    return {
+        ...createTypedDataTemplate(sendOptions.chainId, app),
+        message: {
+            app,
+            nonce,
+            data,
+            max_gas_price: BigInt(sendOptions.maxGasPrice),
+        },
+    };
+};
+
+/** Sends a transaction to L2 */
+export const sendEip712 = async (
+    walletClient: WalletClient,
+    applicationAddress: Address,
+    payload: Hex,
+    sendOptions?: Partial<SendOptions>
+): Promise<string> => {
+    if (!walletClient.account) {
+        throw new Error("Wallet account is missing.");
+    }
+
+    const options = { ...DEFAULT_SEND_CONFIG, ...sendOptions };
+    const account = walletClient.account.address;
+
+    const nonce = await getNonceForEip712(applicationAddress, account, options);
+    const typedData = await createEip712TypedData(applicationAddress, payload, nonce, options);
+    const signature = await walletClient.signTypedData({ account, ...typedData });
+
+    const { id } = await postEip712Transaction({ typedData, account, signature }, options);
+    return id;
+};

--- a/apps/cli/src/commands/send/generic.ts
+++ b/apps/cli/src/commands/send/generic.ts
@@ -15,6 +15,7 @@ import {
     getInputApplicationAddress,
     SendCommandOpts,
 } from "../send.js";
+import { DEFAULT_SEND_CONFIG, sendEip712 } from "./eip712.js";
 
 const getInput = async (options: {
     input?: string;
@@ -111,6 +112,19 @@ export const createGenericCommand = () => {
                 "input encoding",
             ).choices(["hex", "string", "abi"]),
         )
+        .addOption(
+            new Option(
+                "--type <type>",
+                "Transaction type",
+            ).choices(["evm", "eip712"])
+            .default("evm"),
+        )
+        .addOption(
+            new Option(
+                "--eip712-tx-url <url>",
+                "EIP-712 base url",
+            ).default(DEFAULT_SEND_CONFIG.eip712TxUrl),
+        )
         .option("--input-abi-params <input-abi-params>", "input abi params")
         .action(async (options, command) => {
             const sendOptions = command.optsWithGlobals();
@@ -126,6 +140,14 @@ export const createGenericCommand = () => {
             const payload =
                 (await getInput(options)) ||
                 (await bytesInput({ message: "Input" }));
+            if (options.type === 'eip712') {
+                const progress = ora("Sending input...").start();
+                const hash = await sendEip712(walletClient, applicationAddress, payload, {
+                    eip712TxUrl: options.eip712TxUrl,
+                })
+                progress.succeed(`Input sent: ${hash}`);
+                return
+            }
             const { request } = await publicClient.simulateContract({
                 address: inputBoxAddress,
                 abi: inputBoxAbi,


### PR DESCRIPTION
Implementation related to the discussion at https://github.com/cartesi/cli/issues/171 and https://github.com/cartesi/cli/pull/176

```sh
cartesi send generic --help
Usage: cartesi send generic [options]

Sends generics inputs to the application, optionally in interactive mode.

Options:
  --dapp <address>                       Application address
  --chain-id <id>                        Chain ID
  --rpc-url <url>                        RPC URL
  --mnemonic <phrase>                    Mnemonic passphrase
  --mnemonic-index <index>               Mnemonic account index (default: 0)
  --input <input>                        input payload
  --input-encoding <input-encoding>      input encoding (choices: "hex", "string", "abi")
  --type <type>                          Transaction type (choices: "evm", "eip712", default: "evm")
  --eip712-tx-url <url>                  EIP-712 base url (default: "http://localhost:8080/transaction")
  --input-abi-params <input-abi-params>  input abi params
  -h, --help                             display help for command
```

Usage

```sh
cartesi send generic --type=eip712 --input=0xdeadbeef
✔ Chain Foundry
✔ RPC URL http://127.0.0.1:8545
✔ Wallet Mnemonic
✔ Mnemonic test test test test test test test test test test test junk
✔ Account 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 9999.980803715081379185 ETH
✔ Application address 0x75135d8ADb7180640d29d822D9AD59E83E8695b2
✔ Input sent: 0xd1748d033ccbb7e669548350bf7a53336dfdaf79dcb077f2ff745a0446d60127
```
