### PR TITLE
Install modern nodejs using nvm

### DIFF
--- a/.changeset/three-zebras-lead.md
+++ b/.changeset/three-zebras-lead.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+install modern nodejs using nvm

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -272,6 +272,8 @@ ARG CARTESI_MACHINE_EMULATOR_VERSION
 ARG CARTESI_PAYMASTER_VERSION
 ARG CARTESI_PASSKEY_SERVER_VERSION
 ARG CARTESI_ROLLUPS_NODE_VERSION
+ARG NODE_VERSION
+ARG NVM_VERSION
 ARG TARGETARCH
 ARG TARGETARCH
 ARG XGENEXT2_VERSION
@@ -286,13 +288,22 @@ apt-get install -y --no-install-recommends \
     libslirp0 \
     locales \
     lua5.4 \
-    nodejs \
-    npm \
     squashfs-tools \
     xxd \
     xz-utils
 rm -rf /var/lib/apt/lists/*
 EOF
+
+# Install nvm and node
+ENV NVM_DIR=/root/.nvm
+RUN <<EOF
+curl -o- --fail --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+. "$NVM_DIR/nvm.sh"
+nvm install $NODE_VERSION
+nvm use $NODE_VERSION
+nvm alias default $NODE_VERSION
+EOF
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:$PATH"
 
 # Install e2fsprogs from backports
 RUN <<EOF
@@ -325,8 +336,8 @@ npm install -g \
     @pimlico/alto@${ALTO_VERSION}
 
 mkdir -p /usr/share/cartesi
-cp -r /usr/local/lib/node_modules/@cartesi/devnet/deployments /usr/share/cartesi/
-cp /usr/local/lib/node_modules/@cartesi/devnet/anvil_state.json /usr/share/cartesi/
+cp -r "$(npm root -g)/@cartesi/devnet/deployments" /usr/share/cartesi/
+cp "$(npm root -g)/@cartesi/devnet/anvil_state.json" /usr/share/cartesi/
 EOF
 
 # Install linux kernel image

--- a/packages/sdk/alto
+++ b/packages/sdk/alto
@@ -1,2 +1,2 @@
 #!/bin/sh
-node "/usr/local/lib/node_modules/@pimlico/alto/esm/cli/index.js" $@
+node "$(npm root -g)/@pimlico/alto/esm/cli/index.js" $@

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -21,6 +21,8 @@ target "default" {
     ESPRESSO_DEV_NODE_BASE_IMAGE      = "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250428-dev-node-decaf-pos@sha256:78024bc092d51b47e81c0f715dc7a87ac9da81f62a4f8bf3165b3a199f9867fb"
     FOUNDRY_VERSION                   = "1.0.0"
     GO_MIGRATE_VERSION                = "4.18.2"
+    NODE_VERSION                      = "22.15.1"
+    NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17@sha256:7f29c02ba9eeff4de9a9f414d803faa0e6fe5e8d15ebe217e3e418c82e652b35"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"


### PR DESCRIPTION
```
$ docker run cartesi/sdk:devel node --version
v22.15.1
$ docker run cartesi/sdk:devel npm --version
10.9.2
$ docker run cartesi/sdk:devel alto --version
0.0.4
$ docker run cartesi/sdk:devel passkey-server --help
Usage: passkey-server [options]

Options:
  -p, --port <port>  port to listen on (default: 3000)
  -h, --help         display help for command
```
