### PR TITLE
Revert "fix(cli): keep evm-reader enabled"

### DIFF
--- a/apps/cli/src/compose/docker-compose-espresso.yaml
+++ b/apps/cli/src/compose/docker-compose-espresso.yaml
@@ -37,6 +37,10 @@ services:
             timeout: 1s
             retries: 5
 
+    rollups-node:
+        environment:
+            CARTESI_FEATURE_INPUT_READER_ENABLED: false
+
     espresso_reader:
         image: ${CARTESI_SDK_IMAGE}
         command: ["cartesi-rollups-espresso-reader"]


### PR DESCRIPTION
This reverts commit 2949c5123663e009a97f24767fee35bc18100926.

---

My last understanding of this is that, when we enable `--services espresso` we should disable `CARTESI_FEATURE_INPUT_READER_ENABLED`.
