### PR TITLE
feat(cli): add hidden start --runtime-version option

### DIFF
--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -220,6 +220,7 @@ export const createStartCommand = () => {
                 port,
                 services,
                 verbose,
+                runtimeVersion,
             } = options;
             // path of the tool instalation
             const binPath = path.join(
@@ -237,7 +238,7 @@ export const createStartCommand = () => {
                 CARTESI_ROLLUPS_NODE_CPUS: cpus?.toString(),
                 CARTESI_ROLLUPS_NODE_MEMORY: memory?.toString(),
                 CARTESI_SDK_IMAGE: DEFAULT_SDK_IMAGE,
-                CARTESI_SDK_VERSION: options.runtimeVersion.toString(),
+                CARTESI_SDK_VERSION: runtimeVersion?.toString(),
             };
 
             // build a list of unique compose files

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -238,7 +238,7 @@ export const createStartCommand = () => {
                 CARTESI_ROLLUPS_NODE_CPUS: cpus?.toString(),
                 CARTESI_ROLLUPS_NODE_MEMORY: memory?.toString(),
                 CARTESI_SDK_IMAGE: DEFAULT_SDK_IMAGE,
-                CARTESI_SDK_VERSION: runtimeVersion?.toString(),
+                CARTESI_SDK_VERSION: runtimeVersion,
             };
 
             // build a list of unique compose files

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -154,6 +154,14 @@ export const createStartCommand = () => {
     return new Command("start")
         .description("Start a local environment.")
         .configureHelp({ showGlobalOptions: true })
+        .addOption(
+            new Option(
+                "--runtime-version <version>",
+                "version for Cartesi Rollups Runtime to use",
+            )
+                .default(DEFAULT_SDK_VERSION)
+                .hideHelp(),
+        )
         .option(
             "--environment-name <string>",
             "name of environment",
@@ -229,7 +237,7 @@ export const createStartCommand = () => {
                 CARTESI_ROLLUPS_NODE_CPUS: cpus?.toString(),
                 CARTESI_ROLLUPS_NODE_MEMORY: memory?.toString(),
                 CARTESI_SDK_IMAGE: DEFAULT_SDK_IMAGE,
-                CARTESI_SDK_VERSION: DEFAULT_SDK_VERSION,
+                CARTESI_SDK_VERSION: options.runtimeVersion.toString(),
             };
 
             // build a list of unique compose files


### PR DESCRIPTION
Since it's internal use only option, I don't think it deserves a changeset.

This will allow testing a runtime built locally from  `packages/sdk`.

```
cartesi start --runtime-version devel --dry-run
```