### PR TITLE
Fix start port

### DIFF
--- a/.changeset/khaki-shirts-fly.md
+++ b/.changeset/khaki-shirts-fly.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix start port parsing

--- a/apps/cli/src/commands/deploy.ts
+++ b/apps/cli/src/commands/deploy.ts
@@ -198,7 +198,7 @@ const registerApplication = async (options: {
         dataAvailability,
     } = options;
 
-    // use template hash as the name of the deployment
+    // use application address as the name of the deployment
     const name =
         options.name ??
         (await input({

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -201,12 +201,7 @@ export const createStartCommand = () => {
             commaSeparatedList,
             [],
         )
-        .option(
-            "-p, --port <number>",
-            "port to listen on",
-            Number.parseInt,
-            8080,
-        )
+        .option("-p, --port <number>", "port to listen on", Number, 8080)
         .option("--dry-run", "show the docker compose configuration", false)
         .option("-v, --verbose", "verbose output", false)
         .action(async (options, command) => {


### PR DESCRIPTION
If we use `Number.parseInt` to commander it doesn't work  because commander calls the function with two values, the string passed by the user, and the default value. But the `Number.parseInt` function expects a second argument which is the `radix` of the number, while it is receiving the default value.

The fix uses just `Number`, which works because it will construct a number from the string.
