### PR TITLE
Experimental porto support

### DIFF
--- a/apps/cli/src/compose/docker-compose-anvil.yaml
+++ b/apps/cli/src/compose/docker-compose-anvil.yaml
@@ -22,7 +22,7 @@ configs:
 services:
     anvil:
         image: ${CARTESI_SDK_IMAGE}
-        command: ["devnet", "--block-time", "${CARTESI_BLOCK_TIME:-2}"]
+        command: ["devnet", "--odyssey", "--block-time", "${CARTESI_BLOCK_TIME:-2}"]
         healthcheck:
             test: ["CMD", "eth_isready"]
             start_period: 10s

--- a/apps/cli/src/compose/docker-compose-porto.yaml
+++ b/apps/cli/src/compose/docker-compose-porto.yaml
@@ -1,0 +1,74 @@
+services:
+    porto-relay:
+        image: ghcr.io/ithacaxyz/relay:3fc0de2
+        platform: linux/x86_64
+        depends_on:
+            anvil:
+                condition: service_healthy
+        expose:
+            - 9119
+        environment:
+            RUST_LOG: warn
+            RELAY_MNEMONIC: ${CARTESI_AUTH_MNEMONIC:-test test test test test test test test test test test junk}
+        command: ["--config-only"]
+        healthcheck:
+            test:
+                [
+                    "CMD",
+                    "cast",
+                    "rpc",
+                    "--rpc-url",
+                    "http://localhost:9119",
+                    "health",
+                ]
+            interval: 2s
+            retries: 5
+        volumes:
+            - ./porto:/app
+
+    porto-rpc:
+        image: oven/bun:latest
+        expose:
+            - 9220
+        volumes:
+            - ./porto/proxy.ts:/app/proxy.ts
+        command: ["bun", "run", "/app/proxy.ts"]
+        depends_on:
+            anvil:
+                condition: service_healthy
+        environment:
+            PORT: 9220
+            RELAY_URL: http://porto-relay:9119
+            ANVIL_URL: http://anvil:8545
+
+    porto-dialog:
+        image: ${CARTESI_SDK_IMAGE}
+        command:
+            ["busybox", "httpd", "-f", "-h", "/usr/share/porto/dialog", "-vv"]
+        expose:
+            - 80
+        healthcheck:
+            test: ["CMD", "curl", "-fsS", "http://127.0.0.1/"]
+            start_period: 10s
+            start_interval: 200ms
+            interval: 10s
+            timeout: 1s
+            retries: 5
+
+    porto-manager:
+        image: ${CARTESI_SDK_IMAGE}
+        command:
+            ["busybox", "httpd", "-f", "-h", "/usr/share/porto/manager", "-vv"]
+        expose:
+            - 80
+        healthcheck:
+            test: ["CMD", "curl", "-fsS", "http://127.0.0.1/"]
+            start_period: 10s
+            start_interval: 200ms
+            interval: 10s
+            timeout: 1s
+            retries: 5
+
+    proxy:
+        volumes:
+            - ./proxy/porto.yaml:/etc/traefik/conf.d/porto.yaml

--- a/apps/cli/src/compose/docker-compose-proxy.yaml
+++ b/apps/cli/src/compose/docker-compose-proxy.yaml
@@ -1,6 +1,6 @@
 services:
     proxy:
-        image: traefik:v3.3.4
+        image: traefik:v3.4.1
         healthcheck:
             test: ["CMD", "traefik", "healthcheck", "--ping"]
             start_period: 10s
@@ -18,7 +18,8 @@ services:
                 "--providers.file.directory=/etc/traefik/conf.d",
                 "--providers.file.watch=true",
                 "--log",
-                "--log.level=INFO",
+                "--log.level=DEBUG",
+                "--accesslog=true",
             ]
         ports:
             - ${CARTESI_LISTEN_PORT:-6751}:8088

--- a/apps/cli/src/compose/porto/proxy.ts
+++ b/apps/cli/src/compose/porto/proxy.ts
@@ -1,0 +1,20 @@
+Bun.serve({
+    async fetch(request) {
+        if (request.method === "GET") return new Response("Nada");
+
+        const body = await request.json();
+        const target =
+            body.method &&
+            (body.method.startsWith("wallet_") || body.method === "health")
+                ? Bun.env.RELAY_URL!
+                : Bun.env.ANVIL_URL!;
+        return fetch(target, {
+            body: JSON.stringify(body),
+            headers: {
+                "Content-Type": "application/json",
+            },
+            method: "POST",
+        });
+    },
+    port: Number(Bun.env.PORT!),
+});

--- a/apps/cli/src/compose/porto/registry.yaml
+++ b/apps/cli/src/compose/porto/registry.yaml
@@ -1,0 +1,6 @@
+"13370":
+    - address: 0x700b6A60ce7EaaEA56F065753d8dcB9653dbAD35
+      kind: USDT
+    - address: 0xA15BB66138824a1c7167f5E85b957d04Dd34E468
+      kind: USDT
+    - kind: ETH

--- a/apps/cli/src/compose/porto/relay.yaml
+++ b/apps/cli/src/compose/porto/relay.yaml
@@ -1,0 +1,43 @@
+server:
+    address: 0.0.0.0
+    port: 9119
+    metrics_port: 9120
+    max_connections: 5000
+chain:
+    endpoints:
+        - http://anvil:8545
+    sequencer_endpoints: {}
+    fee_tokens:
+        - "0x0000000000000000000000000000000000000000"
+        - "0x700b6A60ce7EaaEA56F065753d8dcB9653dbAD35"
+        - "0xA15BB66138824a1c7167f5E85b957d04Dd34E468"
+    fee_recipient: "0x0000000000000000000000000000000000000000"
+quote:
+    constantRate: 1.0
+    gas:
+        intentBuffer: 100000
+        txBuffer: 100000
+    ttl: 30
+    rateTtl: 300
+onramp:
+    banxa:
+        apiUrl: https://api.banxa-sandbox.com/
+        blockchain: base
+        secrets:
+            api_key: ""
+transactions:
+    num_signers: 16
+    max_pending_transactions: 100
+    max_transactions_per_signer: 16
+    max_queued_per_eoa: 1
+    balance_check_interval: 5
+    nonce_check_interval: 60
+    transaction_timeout: 60
+    public_node_endpoints: {}
+    priority_fee_percentile: 20
+orchestrator: "0xA16c8d51c3E2e80509489eF5147d30b33Af4E233"
+legacy_orchestrators: []
+legacy_delegations: []
+delegation_proxy: "0x4F3Ab48173433c831741262Ac71B6c78D6d0C622"
+simulator: "0xDe8e1bF42165bB8223DC3889AE0901D966834F41"
+database_url: null

--- a/apps/cli/src/compose/proxy/porto.yaml
+++ b/apps/cli/src/compose/proxy/porto.yaml
@@ -1,0 +1,55 @@
+http:
+    routers:
+        porto-rpc:
+            rule: "Path(`/porto/rpc`)"
+            middlewares:
+                - cors
+                - remove-porto-rpc-prefix
+            service: porto-rpc
+        porto-dialog:
+            rule: "PathPrefix(`/porto/dialog`)"
+            middlewares:
+                - remove-porto-dialog-prefix
+            service: porto-dialog
+        porto-manager:
+            rule: "PathPrefix(`/porto/manager`)"
+            middlewares:
+                - remove-porto-manager-prefix
+            service: porto-manager
+    middlewares:
+        remove-porto-rpc-prefix:
+            replacePathRegex:
+                regex: "^/porto/rpc"
+                replacement: ""
+        remove-porto-dialog-prefix:
+            replacePathRegex:
+                regex: "^/porto/dialog/(.*)"
+                replacement: "/$1"
+        remove-porto-manager-prefix:
+            replacePathRegex:
+                regex: "^/porto/manager/(.*)"
+                replacement: "/$1"
+        cors:
+            headers:
+                accessControlAllowMethods:
+                    - GET
+                    - OPTIONS
+                    - PUT
+                accessControlAllowHeaders: "*"
+                accessControlAllowOriginList:
+                    - "*"
+                accessControlMaxAge: 100
+                addVaryHeader: true
+    services:
+        porto-rpc:
+            loadBalancer:
+                servers:
+                    - url: "http://porto-rpc:9220"
+        porto-dialog:
+            loadBalancer:
+                servers:
+                    - url: "http://porto-dialog:80"
+        porto-manager:
+            loadBalancer:
+                servers:
+                    - url: "http://porto-manager:80"

--- a/apps/cli/src/exec/rollups.ts
+++ b/apps/cli/src/exec/rollups.ts
@@ -188,6 +188,15 @@ const availableServices: Service[] = [
         waitTitle: `${chalk.cyan("passkey")} service starting...`,
         errorTitle: `${chalk.red("passkey")} service failed`,
     },
+    {
+        name: "porto",
+        file: "docker-compose-porto.yaml",
+        healthySemaphore: "porto-relay",
+        healthyTitle: (port) =>
+            `${chalk.cyan("porto")} service ready at ${chalk.cyan(`${host}:${port}/porto/{rpc,dialog,manager}`)}`,
+        waitTitle: `${chalk.cyan("porto")} service starting...`,
+        errorTitle: `${chalk.red("porto")} service failed`,
+    },
 ];
 
 export const AVAILABLE_SERVICES = availableServices.map(({ name }) => name);

--- a/packages/devnet/cannonfile.toml
+++ b/packages/devnet/cannonfile.toml
@@ -77,6 +77,12 @@ source = "alchemy-light-account:2.0.0@main"
 [pull.alchemyModularAccountV2]
 source = "alchemy-modular-account:2.0.0@main"
 
+[pull.portoAccount]
+source = "porto-account:0.2.0@main"
+
+[pull.portoDemo]
+source = "porto-demo:0.0.28@main"
+
 [var.Settings]
 token_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -216,6 +216,22 @@ FROM ${POSTGRES_BASE_IMAGE} AS rollups-database
 COPY --from=postgresql-initdb /var/lib/postgresql/data /var/lib/postgresql/data
 
 ################################################################################
+# porto build
+FROM node:${NODE_VERSION} AS porto
+ARG PORTO_VERSION
+
+WORKDIR /src/app
+
+RUN <<EOF
+corepack enable pnpm
+git clone --branch feature/cartesi --depth 1 --recurse-submodules https://github.com/tuler/porto
+cd porto
+pnpm install
+ANVIL=true pnpm --filter dialog build --base /porto/dialog
+ANVIL=true pnpm --filter manager build --base /porto/manager
+EOF
+
+################################################################################
 # alto build
 FROM node:${NODE_VERSION} AS alto
 ARG ALTO_VERSION
@@ -265,6 +281,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends \
+    busybox \
     jq \
     libarchive-tools \
     libslirp0 \
@@ -323,6 +340,10 @@ mkdir -p /usr/share/cartesi
 cp -r "$(npm root -g)/@cartesi/devnet/deployments" /usr/share/cartesi/
 cp "$(npm root -g)/@cartesi/devnet/anvil_state.json" /usr/share/cartesi/
 EOF
+
+# porto webapps
+COPY --from=porto /src/app/porto/apps/dialog/dist/dialog /usr/share/porto/dialog
+COPY --from=porto /src/app/porto/apps/manager/dist /usr/share/porto/manager
 
 # Install linux kernel image
 RUN <<EOF

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -22,6 +22,7 @@ target "default" {
     GO_MIGRATE_VERSION                = "4.18.2"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
+    PORTO_VERSION                     = "0.0.28"
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17@sha256:7f29c02ba9eeff4de9a9f414d803faa0e6fe5e8d15ebe217e3e418c82e652b35"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"


### PR DESCRIPTION
First build porto cannon packages:
```
git clone git@github.com:tuler/porto-account.git
cd porto-account
git checkout v0.2.0-cannon
cannon build
```

```
git clone git@github.com:tuler/porto.git
cd porto
git checkout feature/cannon
cd contracts/demo
cannon build
```

Then build CLI devnet
```
pnpm run build --filter @cartesi/devnet --force
cp packages/devnet/anvil_state.json packages/sdk
cp -R packages/devnet/deployments packages/sdk
cp -R packages/devnet/deployments apps/cli
pnpm run build --filter @cartesi/sdk --force
pnpm run build --filter @cartesi/cli
```

Then start CLI with
```
tsx apps/cli/src/index.ts start --services porto --runtime-version devel
```

Then test with
```
cast bn --rpc-url http://localhost:8080/porto/rpc
```
