### PR TITLE
Change default port from 8080 to 6751

### DIFF
--- a/.changeset/dry-dogs-drive.md
+++ b/.changeset/dry-dogs-drive.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump @cartesi/devnet to 2.0.0-alpha.7

--- a/.changeset/strong-nails-raise.md
+++ b/.changeset/strong-nails-raise.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+change default port from 8080 to 6751

--- a/.changeset/tricky-bees-accept.md
+++ b/.changeset/tricky-bees-accept.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump cartesi/sdk to v0.12.0-alpha.19

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "catalog:",
-        "@cartesi/devnet": "2.0.0-alpha.6",
+        "@cartesi/devnet": "2.0.0-alpha.7",
         "@cartesi/rollups": "2.0.0",
         "@types/bytes": "^3.1.5",
         "@types/fs-extra": "^11.0.4",

--- a/apps/cli/src/commands/send/eip712.ts
+++ b/apps/cli/src/commands/send/eip712.ts
@@ -8,7 +8,7 @@ type SendOptions = {
 };
 
 export const DEFAULT_SEND_CONFIG: Readonly<SendOptions> = {
-    eip712TxUrl: "http://localhost:8080/transaction",
+    eip712TxUrl: "http://127.0.0.1:6751/transaction",
     chainId: 31337,
     maxGasPrice: 10,
 } as const;

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -201,7 +201,7 @@ export const createStartCommand = () => {
             commaSeparatedList,
             [],
         )
-        .option("-p, --port <number>", "port to listen on", Number, 8080)
+        .option("-p, --port <number>", "port to listen on", Number, 6751)
         .option("--dry-run", "show the docker compose configuration", false)
         .option("-v, --verbose", "verbose output", false)
         .action(async (options, command) => {

--- a/apps/cli/src/compose/docker-compose-proxy.yaml
+++ b/apps/cli/src/compose/docker-compose-proxy.yaml
@@ -21,4 +21,4 @@ services:
                 "--log.level=INFO",
             ]
         ports:
-            - ${CARTESI_LISTEN_PORT:-8080}:8088
+            - ${CARTESI_LISTEN_PORT:-6751}:8088

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -76,7 +76,7 @@ export const DEFAULT_COMPOSE_ENVIRONMENT_NAME = "cartesi-rollups";
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
 const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.15";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.19";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 
 type Builder = "directory" | "docker" | "empty" | "none" | "tar";

--- a/apps/cli/src/wallet.ts
+++ b/apps/cli/src/wallet.ts
@@ -150,7 +150,7 @@ const selectTransport = async (
 
     // if the chain is cannon and URL is valid, use it without asking the user
     if (chain.id === cannon.id) {
-        const port = 8080; // XXX: how to get environment port?
+        const port = 6751; // XXX: how to get environment port?
         const url = `http://127.0.0.1:${port}/anvil`;
         if (await testChainUrl(chain, url)) {
             return http(url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: 'catalog:'
         version: 1.9.4
       '@cartesi/devnet':
-        specifier: 2.0.0-alpha.6
-        version: 2.0.0-alpha.6
+        specifier: 2.0.0-alpha.7
+        version: 2.0.0-alpha.7
       '@cartesi/rollups':
         specifier: 2.0.0
         version: 2.0.0
@@ -362,8 +362,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cartesi/devnet@2.0.0-alpha.6':
-    resolution: {integrity: sha512-l3Hl7e9xl9jrVFuYXTkBYtiSUZTQJySv6Tp8OHfIaHsxta0sJhSLsQuhMjIBXKIZmE0wb6zBJeSHQ19GJpQEQA==}
+  '@cartesi/devnet@2.0.0-alpha.7':
+    resolution: {integrity: sha512-uZMt9qRCNVw48FMI+ymjCL/B6S0PekSe0DTlF2ycDeO1T/6GS7zXgI2Qjvraga1fNyGXxU02jNjJGGhWIKD9IQ==}
 
   '@cartesi/rollups@2.0.0':
     resolution: {integrity: sha512-41Dtq73wD5JTepuryUiXumjMNx/e5AlOROKlao4/A0rG34R8emblnTGwvMaMpzKd+USDk2M/aLtIPZ6tnDXD/g==}
@@ -4149,7 +4149,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@cartesi/devnet@2.0.0-alpha.6': {}
+  '@cartesi/devnet@2.0.0-alpha.7': {}
 
   '@cartesi/rollups@2.0.0': {}
 


### PR DESCRIPTION
This PR changes the default port from 8080 to 6751.
I want to define a new `chain` called ` cartesi`, that will come pre-configured with the default url of `http://127.0.0.1:6751/anvil`.
I think the port `8080`, which is usually an alternative "local http" is not the best choice for us.
The port `6751` is a joke with `CTSI`. It's not an assigned port in the [IANA list](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers).
