### PR TITLE
Bump devnet and sdk

### DIFF
--- a/.changeset/dry-dogs-drive.md
+++ b/.changeset/dry-dogs-drive.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump @cartesi/devnet to 2.0.0-alpha.7

--- a/.changeset/tricky-bees-accept.md
+++ b/.changeset/tricky-bees-accept.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump cartesi/sdk to v0.12.0-alpha.19

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "catalog:",
-        "@cartesi/devnet": "2.0.0-alpha.6",
+        "@cartesi/devnet": "2.0.0-alpha.7",
         "@cartesi/rollups": "2.0.0",
         "@types/bytes": "^3.1.5",
         "@types/fs-extra": "^11.0.4",

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -76,7 +76,7 @@ export const DEFAULT_COMPOSE_ENVIRONMENT_NAME = "cartesi-rollups";
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
 const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.15";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.19";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 
 type Builder = "directory" | "docker" | "empty" | "none" | "tar";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: 'catalog:'
         version: 1.9.4
       '@cartesi/devnet':
-        specifier: 2.0.0-alpha.6
-        version: 2.0.0-alpha.6
+        specifier: 2.0.0-alpha.7
+        version: 2.0.0-alpha.7
       '@cartesi/rollups':
         specifier: 2.0.0
         version: 2.0.0
@@ -362,8 +362,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cartesi/devnet@2.0.0-alpha.6':
-    resolution: {integrity: sha512-l3Hl7e9xl9jrVFuYXTkBYtiSUZTQJySv6Tp8OHfIaHsxta0sJhSLsQuhMjIBXKIZmE0wb6zBJeSHQ19GJpQEQA==}
+  '@cartesi/devnet@2.0.0-alpha.7':
+    resolution: {integrity: sha512-uZMt9qRCNVw48FMI+ymjCL/B6S0PekSe0DTlF2ycDeO1T/6GS7zXgI2Qjvraga1fNyGXxU02jNjJGGhWIKD9IQ==}
 
   '@cartesi/rollups@2.0.0':
     resolution: {integrity: sha512-41Dtq73wD5JTepuryUiXumjMNx/e5AlOROKlao4/A0rG34R8emblnTGwvMaMpzKd+USDk2M/aLtIPZ6tnDXD/g==}
@@ -4149,7 +4149,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@cartesi/devnet@2.0.0-alpha.6': {}
+  '@cartesi/devnet@2.0.0-alpha.7': {}
 
   '@cartesi/rollups@2.0.0': {}
 


### PR DESCRIPTION
This pull request updates dependencies and default configurations in the `@cartesi/cli` package. The changes include bumping versions for `@cartesi/devnet` and `cartesi/sdk` to align with the latest releases.

### Dependency Updates:

* [`apps/cli/package.json`](diffhunk://#diff-1625a7848c01883721bcd146381e2a6bff3c03814d4586559265d8e54a0c9565L46-R46): Changed the `@cartesi/devnet` dependency from `2.0.0-alpha.6` to `2.0.0-alpha.7`.

### Configuration Updates:

* [`apps/cli/src/config.ts`](diffhunk://#diff-3493b0baf9d6618ddea715c015f8fe4793c763eb1bb69d70230cad7b9ab541f2L79-R79): Updated the `DEFAULT_SDK_VERSION` constant from `0.12.0-alpha.15` to `0.12.0-alpha.19`.