### PR TITLE
Make sure cannon package follows package version

### DIFF
--- a/packages/devnet/cannonfile.toml
+++ b/packages/devnet/cannonfile.toml
@@ -1,5 +1,5 @@
 name = 'cartesi-rollups-devnet'
-version = '2.0.0-alpha.6'
+version = '<%= package.version %>'
 description = 'Cartesi Rollups Devnet'
 
 [pull.cartesiRollups]


### PR DESCRIPTION
This change makes sure that the cannon package version is the same as the package version.
This is not a big issue in our case because we are not using the publishing of the devnet package. We are saving deployments to the devnet npm package, and using it in the SDK and CLI.
