### PR TITLE
Fix cli build issues

### DIFF
--- a/.changeset/old-flies-retire.md
+++ b/.changeset/old-flies-retire.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix: download image only when it doesn't exists locally

--- a/.changeset/smart-regions-jam.md
+++ b/.changeset/smart-regions-jam.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix: read entrypoint from cartesi.toml

--- a/apps/cli/src/builder/docker.ts
+++ b/apps/cli/src/builder/docker.ts
@@ -92,15 +92,19 @@ export const build = async (
 
     // use pre-existing image or build docker image
     let image: string;
+    let imageInfo: ImageInfo | undefined;
     if (drive.image) {
         image = drive.image;
-        await execa("docker", ["image", "pull", image]);
+        try {
+            imageInfo = await getImageInfo(image);
+        } catch (error) {
+            await execa("docker", ["image", "pull", image]);
+            imageInfo = await getImageInfo(image);
+        }
     } else {
         image = await buildImage(drive);
+        imageInfo = await getImageInfo(image);
     }
-
-    // get image info
-    const imageInfo = await getImageInfo(image);
 
     try {
         // create OCI Docker tarball from Docker image

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -368,6 +368,7 @@ const parseMachine = (value: TomlPrimitive): MachineConfig => {
             toml["assert-rolling-template"],
         ),
         bootargs: parseStringArray(toml.bootargs),
+        entrypoint: parseOptionalString(toml.entrypoint),
         finalHash: parseBoolean(toml["final-hash"], true),
         interactive: undefined,
         maxMCycle: parseOptionalNumber(toml["max-mcycle"]),

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -58,12 +58,18 @@ export const bootMachine = async (
     );
 
     // entrypoint from config or image info (Docker ENTRYPOINT + CMD)
-    const entrypoint =
-        machine.entrypoint ?? // takes priority
-        (info ? [...info.entrypoint, ...info.cmd].join(" ") : undefined); // ENTRYPOINT and CMD as a space separated string
+    let entrypoint: string | undefined;
+
+    if (machine.entrypoint) {
+        entrypoint = machine.entrypoint;
+    } else if (info && (info.entrypoint.length > 0 || info.cmd.length > 0)) {
+        entrypoint = [...info.entrypoint, ...info.cmd].join(" ");
+    }
 
     if (!entrypoint) {
-        throw new Error("Undefined machine entrypoint");
+        throw new Error(
+            "Undefined machine entrypoint. Please define an entrypoint in your cartesi.toml config or in your Dockerfile.",
+        );
     }
 
     const flashDrives = Object.entries(config.drives).map(([label, drive]) =>

--- a/apps/cli/tests/unit/config.test.ts
+++ b/apps/cli/tests/unit/config.test.ts
@@ -116,6 +116,16 @@ shared = true`);
                 new InvalidStringValueError(false),
             );
         });
+        it("should parse entrypoint", () => {
+            const entrypointConfig = `
+                ${config}
+                entrypoint = "echo 'Hello, World!'"
+            `;
+            expect(parse(entrypointConfig)).toEqual({
+                ...defaultConfig(),
+                machine: { ...defaultMachineConfig(), noRollup: true, entrypoint: "echo 'Hello, World!'" },
+            });
+        });
     });
 
     /**


### PR DESCRIPTION
This pull request refines the functionality of Docker image handling and machine booting processes in the CLI application. The changes improve error handling, provide more detailed error messages, and ensure better handling of Docker image information and entrypoints.

### Docker Image Handling Improvements:
* [`apps/cli/src/builder/docker.ts`](diffhunk://#diff-39f662869a776555e1f9f62a9c00a1cab547044b97351791430360b4eaad2a64R95-L104): Enhanced the logic for obtaining Docker image information by introducing a `try-catch` block to handle errors when fetching image info after pulling or building an image. This ensures robust handling of scenarios where the image info retrieval might fail initially.

### Machine Booting Enhancements:
* [`apps/cli/src/machine.ts`](diffhunk://#diff-a8e6ad7ce1b4cb4d3273465adc7a9c6ab8a11372be259a7a07de59e5409ddae7L61-R72): Refactored the logic for determining the machine's entrypoint, adding checks for cases where `entrypoint` or `cmd` are empty arrays. Improved the error message to guide users on how to resolve undefined entrypoints by updating their configuration or Dockerfile.