### PR TITLE
Chore: Bump rollups-explorer image

### DIFF
--- a/.changeset/moody-parrots-fold.md
+++ b/.changeset/moody-parrots-fold.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Bump rollups-explorer to 1.2.0

--- a/apps/cli/src/compose/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/docker-compose-explorer.yaml
@@ -78,7 +78,10 @@ services:
                 condition: service_healthy
 
     explorer:
-        image: cartesi/rollups-explorer:1.0.2
+        image: cartesi/rollups-explorer:1.2.0
+        environment:
+            NODE_RPC_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/anvil"
+            EXPLORER_API_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/explorer-api/graphql"
         expose:
             - 3000
         depends_on:


### PR DESCRIPTION
### Summary
Code changes in that image add support for adapting to port changes (e.g., 6751, 6752, and so on). 