### PR TITLE
Read entrypoint from cartesi.toml

### DIFF
--- a/.changeset/smart-regions-jam.md
+++ b/.changeset/smart-regions-jam.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix: read entrypoint from cartesi.toml

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -368,6 +368,7 @@ const parseMachine = (value: TomlPrimitive): MachineConfig => {
             toml["assert-rolling-template"],
         ),
         bootargs: parseStringArray(toml.bootargs),
+        entrypoint: parseOptionalString(toml.entrypoint),
         finalHash: parseBoolean(toml["final-hash"], true),
         interactive: undefined,
         maxMCycle: parseOptionalNumber(toml["max-mcycle"]),

--- a/apps/cli/tests/unit/config.test.ts
+++ b/apps/cli/tests/unit/config.test.ts
@@ -116,6 +116,16 @@ shared = true`);
                 new InvalidStringValueError(false),
             );
         });
+        it("should parse entrypoint", () => {
+            const entrypointConfig = `
+                ${config}
+                entrypoint = "echo 'Hello, World!'"
+            `;
+            expect(parse(entrypointConfig)).toEqual({
+                ...defaultConfig(),
+                machine: { ...defaultMachineConfig(), noRollup: true, entrypoint: "echo 'Hello, World!'" },
+            });
+        });
     });
 
     /**


### PR DESCRIPTION
The `entrypoint` field in `cartesi.toml` was not being read by the parser.
Added a test case for that as well.
