### PR TITLE
Additional config flags to drive machine build

### DIFF
--- a/.changeset/dirty-crabs-smoke.md
+++ b/.changeset/dirty-crabs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+additional config flags to drive machine build

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -151,6 +151,8 @@ export type MachineConfig = {
     ramLength: string;
     ramImage: string;
     store?: string;
+    useDockerEnv: boolean; // inject docker image ENV into cartesi-machine ENV
+    useDockerWorkdir: boolean; // inject docker image WORKDIR into cartesi-machine WORKDIR
     user?: string; // default given by cartesi-machine
 };
 
@@ -183,6 +185,8 @@ export const defaultMachineConfig = (): MachineConfig => ({
     ramLength: DEFAULT_RAM,
     ramImage: DEFAULT_RAM_IMAGE,
     store: "image",
+    useDockerEnv: true,
+    useDockerWorkdir: true,
     user: undefined,
 });
 
@@ -378,6 +382,8 @@ const parseMachine = (value: TomlPrimitive): MachineConfig => {
         ramLength: parseString(toml.ram_length, DEFAULT_RAM),
         ramImage: parseString(toml.ram_image, DEFAULT_RAM_IMAGE),
         store: "image",
+        useDockerEnv: parseBoolean(toml.use_docker_env, true),
+        useDockerWorkdir: parseBoolean(toml.use_docker_workdir, true),
         user: parseOptionalString(toml.user),
     };
 };

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -35,11 +35,13 @@ export const bootMachine = (
         ramLength,
         ramImage,
         store,
+        useDockerEnv,
+        useDockerWorkdir,
         user,
     } = machine;
 
     // list of environment variables of docker image
-    const env = info?.env ?? [];
+    const env = useDockerEnv ? (info?.env ?? []) : [];
     const envs = env.map((variable) => `--env=${variable}`);
 
     // check if we need a rootfstype boot arg
@@ -92,7 +94,7 @@ export const bootMachine = (
     if (finalHash) {
         args.push("--final-hash");
     }
-    if (info?.workdir) {
+    if (useDockerWorkdir && info?.workdir) {
         args.push(`--workdir="${info.workdir}"`);
     }
     if (interactive) {

--- a/apps/cli/tests/unit/config/fixtures/full.toml
+++ b/apps/cli/tests/unit/config/fixtures/full.toml
@@ -9,6 +9,9 @@
 # no_rollup = false
 # ram_image = "/usr/share/cartesi-machine/images/linux.bin" # directory inside SDK image
 # ram_length = "128Mi"
+# use_docker_env = true
+# use_docker_workdir = true
+# user = "dapp"
 
 # [drives.root]
 # builder = "docker"
@@ -41,4 +44,3 @@
 # builder = "none"
 # filename = "./games/doom.sqfs"
 # mount = "/usr/local/games/doom"
-


### PR DESCRIPTION
New config for `cartesi.toml`
- use_docker_env: inject docker image ENV into cartesi-machine ENV (default: true)
- use_docker_workdir: inject docker image WORKDIR into cartesi-machine WORKDIR (default: true)
