### PR TITLE
Fix ram_image default value

### DIFF
--- a/.changeset/salty-hoops-move.md
+++ b/.changeset/salty-hoops-move.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix ram_image default value

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,6 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-const DEFAULT_RAM_IMAGE = "/usr/share/cartesi-machine/images/linux.bin";
 export const DEFAULT_SDK_VERSION = "0.12.0-alpha.20";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
@@ -147,7 +146,7 @@ export type MachineConfig = {
     maxMCycle?: bigint; // default given by cartesi-machine
     noRollup?: boolean; // default given by cartesi-machine
     ramLength: string;
-    ramImage: string;
+    ramImage?: string; // default given by cartesi-machine
     useDockerEnv: boolean; // inject docker image ENV into cartesi-machine ENV
     useDockerWorkdir: boolean; // inject docker image WORKDIR into cartesi-machine WORKDIR
     user?: string; // default given by cartesi-machine
@@ -178,7 +177,6 @@ export const defaultMachineConfig = (): MachineConfig => ({
     maxMCycle: undefined,
     noRollup: undefined,
     ramLength: DEFAULT_RAM,
-    ramImage: DEFAULT_RAM_IMAGE,
     useDockerEnv: true,
     useDockerWorkdir: true,
     user: undefined,
@@ -372,7 +370,7 @@ const parseMachine = (value: TomlPrimitive): MachineConfig => {
         maxMCycle: parseOptionalNumber(toml.max_mcycle),
         noRollup: parseBoolean(toml.no_rollup, false),
         ramLength: parseString(toml.ram_length, DEFAULT_RAM),
-        ramImage: parseString(toml.ram_image, DEFAULT_RAM_IMAGE),
+        ramImage: parseOptionalString(toml.ram_image),
         useDockerEnv: parseBoolean(toml.use_docker_env, true),
         useDockerWorkdir: parseBoolean(toml.use_docker_workdir, true),
         user: parseOptionalString(toml.user),

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -88,9 +88,11 @@ export const bootMachine = (
         ...bootargs,
         ...envs,
         ...flashDrives,
-        `--ram-image=${ramImage}`,
         `--ram-length=${ramLength}`,
     ];
+    if (ramImage) {
+        args.push(`--ram-image=${ramImage}`);
+    }
     if (assertRollingTemplate) {
         args.push("--assert-rolling-template");
     }


### PR DESCRIPTION
This PR let the default value of the `ram-image` to be driven by the `cartesi-machine` CLI tool (used by `build`).
If `cartesi-machine` is installed in the system (macOS or Linux) the default location of the `linux.bin` will be defined by the `cartesi-machine` installation.
If the CLI uses the `cartesi-machine` from the SDK, then it uses the default value of that.
Either way, if the `cartesi.toml` does not define the value of `ram_image` it will work regardless we use the system `cartesi-machine` or the docker sdk `cartesi-machine`.

Note that if the user defines a `ram_image` in the `cartesi.toml` that path will be used. If it's a system `cartesi-machine` the path will be considered a host path. If it's a docker sdk `cartesi-machine` the path will be considered a path inside the docker sdk.
