### PR TITLE
Fix case of no cartesi.toml

### DIFF
--- a/.changeset/dry-walls-lead.md
+++ b/.changeset/dry-walls-lead.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix case of no cartesi.toml

--- a/apps/cli/src/base.ts
+++ b/apps/cli/src/base.ts
@@ -49,6 +49,9 @@ export const getApplicationConfig = (configPaths: string[]): Config => {
         if (fs.existsSync(configPath)) {
             return fs.readFileSync(configPath).toString();
         }
+        if (configPath === "cartesi.toml") {
+            return "";
+        }
         throw new Error(`Config file ${configPath} does not exist`);
     });
     return parse(tomls);


### PR DESCRIPTION
The latest changes created a bug where build fails if there was no `cartesi.toml` file in the project.
This fixes that.
