### PR TITLE
chore(cli): Bump rollups-explorer ui image to 1.3.3

### DIFF
--- a/.changeset/fluffy-parts-dig.md
+++ b/.changeset/fluffy-parts-dig.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Bump rollups-explorer to version 1.3.3

--- a/apps/cli/src/compose/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/docker-compose-explorer.yaml
@@ -78,7 +78,7 @@ services:
                 condition: service_healthy
 
     explorer:
-        image: cartesi/rollups-explorer:1.2.0
+        image: cartesi/rollups-explorer:1.3.3
         environment:
             NODE_RPC_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/anvil"
             EXPLORER_API_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/explorer-api/graphql"


### PR DESCRIPTION
# Summary

Bumping the latest image published for rollups-explorer UI. 

Releases:
* https://github.com/cartesi/rollups-explorer/releases/tag/v1.3.2
* https://github.com/cartesi/rollups-explorer/releases/tag/v1.3.3


I am closing #325 as it includes everything from that.