### PR TITLE
feat(sdk): update baseimage to Debian 13 (Trixie)

### DIFF
--- a/.changeset/shaggy-guests-look.md
+++ b/.changeset/shaggy-guests-look.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump Debian baseimage to 13 (trixie)

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -109,14 +109,14 @@ EOF
 
 RUN <<EOF
 set -e
-addgroup --system --gid 102 cartesi
-adduser --system --uid 102 \
-    --disabled-login \
-    --gecos "cartesi user" \
-    --home /nonexistent \
-    --ingroup cartesi \
+useradd \
+    --comment "cartesi user" \
     --no-create-home \
-    --shell /bin/false \
+    --home-dir /nonexistent \
+    --shell /usr/sbin/nologin \
+    --system \
+    --uid 102 \
+    --user-group \
     cartesi
 EOF
 

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -8,7 +8,7 @@ target "default" {
   args = {
     ALTO_VERSION                      = "1.2.5"
     ALTO_PACKAGE_VERSION              = "0.0.18"
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb"
+    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.7"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
@@ -22,7 +22,7 @@ target "default" {
     GO_MIGRATE_VERSION                = "4.18.2"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:29e0bb09c8e7e7fc265ea9f4367de9622e55bae6b0b97e7cce740c2d63c2ebc0"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:8a56bef4c60bef3d26193cb9d810fce93def8fd0c459f4a9b14240fbd7559a1d"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -22,7 +22,7 @@ target "default" {
     GO_MIGRATE_VERSION                = "4.18.2"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:19ad070ea172efd48d7cae52297caaf845a3625728674bbc1a6efb679ab7befe"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:29e0bb09c8e7e7fc265ea9f4367de9622e55bae6b0b97e7cce740c2d63c2ebc0"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -8,7 +8,7 @@ target "default" {
   args = {
     ALTO_VERSION                      = "1.2.5"
     ALTO_PACKAGE_VERSION              = "0.0.18"
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20250721-slim@sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8"
+    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.7"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
@@ -22,7 +22,7 @@ target "default" {
     GO_MIGRATE_VERSION                = "4.18.2"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17@sha256:3962158596daaef3682838cc8eb0e719ad1ce520f88e34596ce8d5de1b6330a1"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:19ad070ea172efd48d7cae52297caaf845a3625728674bbc1a6efb679ab7befe"
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }


### PR DESCRIPTION
This pull request updates the base images used in the SDK's Docker configuration to newer Debian and Postgres versions, and refactors the user creation process in the Dockerfile for improved security and compatibility.

**Base image updates:**

* Updated `CARTESI_BASE_IMAGE` from Debian Bookworm to Debian Trixie, advancing the base OS version for the SDK Docker image (`docker-bake.hcl`).
* Updated `POSTGRES_BASE_IMAGE` to use the Trixie-based Postgres image, ensuring consistency with the new Debian base (`docker-bake.hcl`).

**User creation refactor:**

* Replaced the use of `addgroup` and `adduser` with a single `useradd` command in the Dockerfile, aligning with best practices for system user creation and improving security by explicitly setting the shell to `nologin` (`Dockerfile`).