### PR TITLE
fix(cli): quote ENV vars when it contains spaces

### DIFF
--- a/.changeset/chilly-ducks-work.md
+++ b/.changeset/chilly-ducks-work.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+quote ENV vars during build when it contains spaces

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -45,7 +45,13 @@ export const bootMachine = (
 
     // list of environment variables of docker image
     const env = useDockerEnv ? (info?.env ?? []) : [];
-    const envs = env.map((variable) => `--env=${variable}`);
+    const envs = env.map((variable) => {
+        const eqIdx = variable.indexOf("=");
+        const key = variable.slice(0, eqIdx);
+        const value = variable.slice(eqIdx + 1);
+
+        return `--env=${key}="${value}"`;
+    });
 
     // check if we need a rootfstype boot arg
     const root = config.drives.root;

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -46,10 +46,7 @@ export const bootMachine = (
     // list of environment variables of docker image
     const env = useDockerEnv ? (info?.env ?? []) : [];
     const envs = env.map((variable) => {
-        const eqIdx = variable.indexOf("=");
-        const key = variable.slice(0, eqIdx);
-        const value = variable.slice(eqIdx + 1);
-
+        const [key, value] = variable.split("=");
         return `--env=${key}="${value}"`;
     });
 


### PR DESCRIPTION
This pull request addresses an issue with environment variable handling during Docker image builds in the CLI. The main improvement ensures that environment variable values containing spaces are properly quoted, preventing potential errors when passing them to cartesi-machine to boot.

**Environment variable handling improvements:**

* In `apps/cli/src/machine.ts`, updated the logic for constructing cartesi-machine `--env` arguments to detect environment variable values containing spaces and wrap those values in quotes. This ensures correct parsing by Docker when environment variables include spaces.

**Documentation:**

* Added a changeset file `.changeset/chilly-ducks-work.md` documenting this patch and describing the quoting of environment variables with spaces during build.