### PR TITLE
feat(sdk): add nitro process manager

### DIFF
--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -158,7 +158,7 @@ FROM ${POSTGRES_BASE_IMAGE} AS postgresql-initdb
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eo
+set -e
 apt-get update
 apt-get install -y --no-install-recommends \
     libslirp0
@@ -217,6 +217,7 @@ WORKDIR /app
 COPY alto.patch /app/alto.patch
 
 RUN <<EOF
+set -eu
 npm install -g pnpm
 git clone --branch v${ALTO_VERSION} --depth 1 --recurse-submodules https://github.com/pimlicolabs/alto.git
 cd alto
@@ -241,7 +242,6 @@ ARG CARTESI_PASSKEY_SERVER_VERSION
 ARG CARTESI_ROLLUPS_NODE_VERSION
 ARG NODE_VERSION
 ARG NVM_VERSION
-ARG TARGETARCH
 ARG TARGETARCH
 ARG XGENEXT2_VERSION
 

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -149,6 +149,7 @@ EOF
 COPY --from=graphql /usr/local/bin/cartesi-rollups-graphql /usr/local/bin/
 COPY --from=go-migrate /usr/local/bin/migrate /usr/local/bin/
 COPY --from=graphql-migration /usr/share/cartesi/rollups-graphql/migrations /usr/share/cartesi/rollups-graphql/migrations
+COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 
 USER cartesi
 
@@ -339,7 +340,6 @@ COPY eth_dump /usr/local/bin
 COPY eth_load /usr/local/bin
 
 COPY entrypoint.sh /usr/local/bin/
-COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/
 

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -48,6 +48,16 @@ RUN curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDR
     | tar -zx -C /usr/local/bin
 
 ################################################################################
+# nitro installer
+FROM builder AS nitro
+ARG NITRO_VERSION
+WORKDIR /usr/local/src
+ADD https://github.com/leahneukirchen/nitro.git#v${NITRO_VERSION} /usr/local/src
+RUN <<EOF
+make
+EOF
+
+################################################################################
 # go migrate db cli installer
 FROM base AS go-migrate
 ARG GO_MIGRATE_VERSION
@@ -150,6 +160,10 @@ COPY --from=graphql /usr/local/bin/cartesi-rollups-graphql /usr/local/bin/
 COPY --from=go-migrate /usr/local/bin/migrate /usr/local/bin/
 COPY --from=graphql-migration /usr/share/cartesi/rollups-graphql/migrations /usr/share/cartesi/rollups-graphql/migrations
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
+COPY --from=nitro /usr/local/src/nitro /usr/local/bin/
+COPY --from=nitro /usr/local/src/nitroctl /usr/local/bin/
+COPY skel/ /
+RUN mkdir -p /run/nitro && chown -R cartesi:cartesi /run/nitro
 
 USER cartesi
 

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -19,6 +19,7 @@ target "default" {
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.7"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"
+    NITRO_VERSION                     = "0.3"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:8a56bef4c60bef3d26193cb9d810fce93def8fd0c459f4a9b14240fbd7559a1d"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -17,7 +17,6 @@ target "default" {
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.14"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.7"
-    CRANE_VERSION                     = "0.19.1"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"
     NODE_VERSION                      = "22.15.1"

--- a/packages/sdk/skel/etc/nitro/cartesi-rollups-advancer/run
+++ b/packages/sdk/skel/etc/nitro/cartesi-rollups-advancer/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cartesi-rollups-advancer

--- a/packages/sdk/skel/etc/nitro/cartesi-rollups-claimer/run
+++ b/packages/sdk/skel/etc/nitro/cartesi-rollups-claimer/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cartesi-rollups-claimer

--- a/packages/sdk/skel/etc/nitro/cartesi-rollups-evm-reader/run
+++ b/packages/sdk/skel/etc/nitro/cartesi-rollups-evm-reader/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cartesi-rollups-evm-reader

--- a/packages/sdk/skel/etc/nitro/cartesi-rollups-jsonrpc-api/run
+++ b/packages/sdk/skel/etc/nitro/cartesi-rollups-jsonrpc-api/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cartesi-rollups-jsonrpc-api

--- a/packages/sdk/skel/etc/nitro/cartesi-rollups-validator/run
+++ b/packages/sdk/skel/etc/nitro/cartesi-rollups-validator/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cartesi-rollups-validator


### PR DESCRIPTION
This pull request introduces support for the Nitro runtime in the SDK Docker build, along with related configuration and setup improvements. The most important changes include adding a build stage for Nitro, copying Nitro binaries into the final image, and introducing service run scripts for Nitro components. Minor improvements to build reliability and environment variable management are also included.

**Nitro runtime integration:**

* Added a new build stage for Nitro in `packages/sdk/Dockerfile` that fetches and builds the Nitro binaries from the specified version.
* Copied the built `nitro` and `nitroctl` binaries from the Nitro build stage into the final Docker image.
* Introduced a new `NITRO_VERSION` build argument in `packages/sdk/docker-bake.hcl` to control the Nitro version used.

**Service setup for Nitro components:**

* Added run scripts for Nitro services (`cartesi-rollups-advancer`, `cartesi-rollups-claimer`, `cartesi-rollups-evm-reader`, `cartesi-rollups-jsonrpc-api`, `cartesi-rollups-validator`) in the `packages/sdk/skel/etc/nitro/` directory to enable service execution in the container. [[1]](diffhunk://#diff-7624325e4c9f867f7a87e7ed0e3914608b6900633e5cb4b96eef16991ce5cef4R1-R2) [[2]](diffhunk://#diff-2b25aedc95064204a8f64075fc140b756c300b54f39cc4587cc5ee3b38c22f69R1-R2) [[3]](diffhunk://#diff-72c3e58d129783d77ac47c7fd71e581e6ec60288f2755de9251420fb2d961cabR1-R2) [[4]](diffhunk://#diff-2e156647e5b9e3fb769e5dd2a2eb6d70fbed79b07ae547675e0da7bf790aa108R1-R2) [[5]](diffhunk://#diff-bf1e9f2a073ad4d50b2ce22f99a486a45710e18bf5cdfe9338235308de75e70bR1-R2)
* Updated the Dockerfile to copy the `skel/` directory into the image and set ownership appropriately for the `cartesi` user.

**Build and environment improvements:**

* Improved shell script reliability in Dockerfile build steps by switching to `set -e` and `set -eu` where applicable. [[1]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL161-R176) [[2]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR235)
* Cleaned up duplicate Docker build arguments and removed unused ones.
* Removed a redundant copy command for `su-exec` from the Dockerfile.