### PR TITLE
chore(sdk): bump rollups-node to 2.0.0-alpha.7

### DIFF
--- a/.changeset/wise-bananas-make.md
+++ b/.changeset/wise-bananas-make.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump rollups-node to 2.0.0-alpha.7

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -16,7 +16,7 @@ target "default" {
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.14"
-    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.6"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.7"
     CRANE_VERSION                     = "0.19.1"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"


### PR DESCRIPTION
This pull request updates the Cartesi Rollups Node version used in the SDK to `2.0.0-alpha.7`. This ensures that the SDK is compatible with the latest alpha release of the rollups node.

Version bump:

* Updated `CARTESI_ROLLUPS_NODE_VERSION` in `packages/sdk/docker-bake.hcl` from `2.0.0-alpha.6` to `2.0.0-alpha.7` to use the latest rollups node version.
* Documented the version bump in `.changeset/wise-bananas-make.md` for release tracking.