### PR TITLE
feat(cli): adapt to rollups-node:2.0.0-alpha.7

### DIFF
--- a/.changeset/tasty-shoes-dig.md
+++ b/.changeset/tasty-shoes-dig.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+adapt to rollups-node:2.0.0-alpha.7

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.20";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.22";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 

--- a/apps/cli/src/exec/rollups.ts
+++ b/apps/cli/src/exec/rollups.ts
@@ -462,11 +462,7 @@ export const deployApplication = async (options: {
     if (consensus) {
         deployArgs.push("--consensus", consensus);
     } else {
-        deployArgs.push(
-            "--epoch-length",
-            epochLength.toString(),
-            "--self-hosted",
-        );
+        deployArgs.push("--epoch-length", epochLength.toString());
     }
     if (salt) {
         deployArgs.push("--salt", salt);

--- a/apps/cli/tests/integration/builder/docker.test.ts
+++ b/apps/cli/tests/integration/builder/docker.test.ts
@@ -68,7 +68,7 @@ describe("when building with the docker builder", () => {
             await build("root", drive, image, destination, false);
             const filename = path.join(destination, "root.ext2");
             const stat = fs.statSync(filename);
-            expect(stat.size).toEqual(85917696);
+            expect(stat.size).toEqual(93716480);
         },
     );
 
@@ -88,7 +88,7 @@ describe("when building with the docker builder", () => {
         await build("root", drive, image, destination, false);
         const filename = path.join(destination, "root.ext2");
         const stat = fs.statSync(filename);
-        expect(stat.size).toEqual(85917696);
+        expect(stat.size).toEqual(93716480);
     });
 
     tmpdirTest.skip("should build a sqfs drive", async ({ tmpdir }) => {

--- a/apps/cli/tests/integration/builder/fixtures/Dockerfile
+++ b/apps/cli/tests/integration/builder/fixtures/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=linux/riscv64 ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233 AS test
+FROM --platform=linux/riscv64 ubuntu:24.04@sha256:3f83fb03282ef4e453bdf0060e0d83833bb3cf6e6f36f54d9b8517d311d78e03 AS test
 ADD ./file2 .
 
-FROM --platform=linux/riscv64 ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233
+FROM --platform=linux/riscv64 ubuntu:24.04@sha256:3f83fb03282ef4e453bdf0060e0d83833bb3cf6e6f36f54d9b8517d311d78e03
 ADD ./file1 .


### PR DESCRIPTION
This pull request updates the CLI to be compatible with `rollups-node` version `2.0.0-alpha.7` and makes a minor adjustment to the deployment argument handling logic.

Compatibility update:

* Updated the CLI to adapt to `rollups-node:2.0.0-alpha.7`, ensuring continued compatibility with the latest node release.

Deployment logic adjustment:

* Modified the deployment argument construction in `apps/cli/src/exec/rollups.ts` by removing the `--self-hosted` flag when the `consensus` option is not provided, aligning with updated deployment requirements.