### PR TITLE
chore(sdk): bump rollups-node to 2.0.0-alpha.8

### DIFF
--- a/.changeset/clean-dingos-battle.md
+++ b/.changeset/clean-dingos-battle.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump rollups-node to 2.0.0-alpha.8

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -16,7 +16,7 @@ target "default" {
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_GRAPHQL_VERSION   = "2.3.14"
-    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.7"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.8"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"
     NITRO_VERSION                     = "0.3"


### PR DESCRIPTION
This pull request updates the version of the `cartesi-rollups-node` dependency from `2.0.0-alpha.7` to `2.0.0-alpha.8` in the SDK package. This ensures that the project uses the latest features and fixes from the rollups node.

Dependency update:

* Bumped `CARTESI_ROLLUPS_NODE_VERSION` from `2.0.0-alpha.7` to `2.0.0-alpha.8` in `packages/sdk/docker-bake.hcl` and documented the change in the changeset. [[1]](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL19-R19) [[2]](diffhunk://#diff-d89d57adb5443be4e09baa9c6f85650014d2328fd3e57707dfb6b365903a3983R1-R5)