### PR TITLE
chore(cli): bump to cartesi/sdk:0.12.0-alpha.23

### DIFF
--- a/.changeset/cool-flies-fall.md
+++ b/.changeset/cool-flies-fall.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump to cartesi/sdk:0.12.0-alpha.23

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.22";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.23";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 

--- a/apps/cli/tests/integration/config.ts
+++ b/apps/cli/tests/integration/config.ts
@@ -1,1 +1,1 @@
-export const TEST_SDK = "cartesi/sdk:0.12.0-alpha.20";
+export const TEST_SDK = "cartesi/sdk:0.12.0-alpha.23";


### PR DESCRIPTION
This pull request updates the Cartesi SDK version used throughout the CLI project to `0.12.0-alpha.23`. The main goal is to ensure that the CLI and its tests are aligned with the latest SDK release.

Dependency version updates:

* Updated the default SDK version constant in `apps/cli/src/config.ts` to `0.12.0-alpha.23`.
* Updated the test SDK version in `apps/cli/tests/integration/config.ts` to `cartesi/sdk:0.12.0-alpha.23`.

Documentation and metadata:

* Added a changeset file documenting the bump to `cartesi/sdk:0.12.0-alpha.23` for the `@cartesi/cli` package.