### PR TITLE
chore(sdk): bump squashfs-tools to 4.7.2

### DIFF
--- a/.changeset/loose-laws-relax.md
+++ b/.changeset/loose-laws-relax.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump squashfs-tools to 4.7.2

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -26,7 +26,12 @@ apt-get install -y --no-install-recommends \
     automake \
     build-essential \
     libarchive-dev \
-    libtool
+    libtool \
+    liblz4-dev \
+    liblzma-dev \
+    liblzo2-dev \
+    libzstd-dev \
+    zlib1g-dev
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -55,6 +60,17 @@ WORKDIR /usr/local/src
 ADD https://github.com/leahneukirchen/nitro.git#v${NITRO_VERSION} /usr/local/src
 RUN <<EOF
 make
+EOF
+
+################################################################################
+# build msquashfs-tools
+FROM builder AS squashfs-tools
+ARG SQUASHFS_TOOLS_VERSION
+WORKDIR /usr/local/src/squashfs-tools
+ADD https://github.com/plougher/squashfs-tools.git#${SQUASHFS_TOOLS_VERSION}:squashfs-tools .
+RUN <<EOF
+make
+./mksquashfs -version
 EOF
 
 ################################################################################
@@ -270,7 +286,6 @@ apt-get install -y --no-install-recommends \
     libslirp0 \
     locales \
     lua5.4 \
-    squashfs-tools \
     xxd \
     xz-utils
 rm -rf /var/lib/apt/lists/*
@@ -356,6 +371,7 @@ COPY eth_load /usr/local/bin
 COPY entrypoint.sh /usr/local/bin/
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/
+COPY --from=squashfs-tools /usr/local/src/squashfs-tools/mksquashfs /usr/local/bin/
 
 WORKDIR /mnt
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -23,6 +23,7 @@ target "default" {
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:8a56bef4c60bef3d26193cb9d810fce93def8fd0c459f4a9b14240fbd7559a1d"
+    SQUASHFS_TOOLS_VERSION            = "99d23a31b471433c51e9c145aeba2ab1536e34df" # 4.7.2
     SU_EXEC_VERSION                   = "0.2"
     XGENEXT2_VERSION                  = "1.5.6"
   }


### PR DESCRIPTION
This pull request updates the way `squashfs-tools` is provided in the `@cartesi/sdk` Docker image. Instead of installing the pre-built package from the system repositories, it now builds `squashfs-tools` from source at version 4.7.2, ensuring more control over the version and its dependencies. Several development libraries required for building `squashfs-tools` have also been added.

Key changes:

**Switch to building squashfs-tools from source:**
* Removed the installation of the `squashfs-tools` package via `apt` and instead added a build stage in the Dockerfile to compile it from the official GitHub repository at the specified commit for version 4.7.2. The built `mksquashfs` binary is now copied into the final image. [[1]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL273) [[2]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR65-R75) [[3]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR374) [[4]](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bR26) [[5]](diffhunk://#diff-5796889e614e5a2a36e9692abd55ce53f6c74dad15a759761e42e54657dfd752R1-R5)

**Dependency updates:**
* Added development libraries (`liblz4-dev`, `liblzma-dev`, `liblzo2-dev`, `libzstd-dev`, `zlib1g-dev`) to the build environment to support building `squashfs-tools` with all compression options enabled.

**Version tracking:**
* Introduced a `SQUASHFS_TOOLS_VERSION` build argument in `docker-bake.hcl` and set it to the commit corresponding to version 4.7.2, ensuring reproducible builds. [[1]](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bR26) [[2]](diffhunk://#diff-5796889e614e5a2a36e9692abd55ce53f6c74dad15a759761e42e54657dfd752R1-R5)