### PR TITLE
chore(cli): bump to cartesi/sdk:0.12.0-alpha.24

### DIFF
--- a/.changeset/old-chairs-enjoy.md
+++ b/.changeset/old-chairs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
++bump to cartesi/sdk:0.12.0-alpha.24

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.23";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.24";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 


### PR DESCRIPTION
This pull request updates the default Cartesi SDK version used by the CLI from `0.12.0-alpha.23` to `0.12.0-alpha.24`. This ensures that new projects and commands will use the latest SDK version by default.

SDK version bump:

* Updated the `DEFAULT_SDK_VERSION` constant in `apps/cli/src/config.ts` to use `0.12.0-alpha.24` instead of the previous version.
* Added a changeset entry documenting the bump to `cartesi/sdk:0.12.0-alpha.24`.