### PR TITLE
fix(sdk): add squashfs-tools missing liblzo2 runtime dependency

### DIFF
--- a/.changeset/cold-ducks-vanish.md
+++ b/.changeset/cold-ducks-vanish.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+add squashfs-tools missing liblzo2 runtime dependency

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -283,6 +283,7 @@ apt-get update
 apt-get install -y --no-install-recommends \
     jq \
     libarchive-tools \
+    liblzo2-2 \
     libslirp0 \
     locales \
     lua5.4 \


### PR DESCRIPTION
This pull request addresses a missing runtime dependency for `squashfs-tools` in the SDK Docker image, ensuring proper functionality and stability.

**Dependency Fixes:**

* Added `liblzo2-2` as a required package in `packages/sdk/Dockerfile` to resolve the missing runtime dependency for `squashfs-tools`.
* Documented the change in `.changeset/cold-ducks-vanish.md` for release tracking.