### PR TITLE
bump to cartesi/sdk:0.12.0-alpha.25

### DIFF
--- a/.changeset/poor-donkeys-accept.md
+++ b/.changeset/poor-donkeys-accept.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump to cartesi/sdk:0.12.0-alpha.25

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.24";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.25";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 


### PR DESCRIPTION
This pull request updates the default Cartesi SDK version used by the CLI to `0.12.0-alpha.25` and documents this change in the changelog.

Version bump:

* Updated the `DEFAULT_SDK_VERSION` constant in `apps/cli/src/config.ts` from `0.12.0-alpha.24` to `0.12.0-alpha.25`, ensuring the CLI uses the latest SDK version by default.

Changelog update:

* Added a changeset file `.changeset/poor-donkeys-accept.md` to record the version bump to `cartesi/sdk:0.12.0-alpha.25`.