### PR TITLE
ci: remove NPM_TOKEN in favor of OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,6 @@ jobs:
                   publish: pnpm run publish-packages
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     packages_to_build:
         name: Get released packages


### PR DESCRIPTION
This pull request makes a small change to the release workflow configuration by removing the `NPM_TOKEN` environment variable from the publish step.

References: 

  - https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/
  - https://docs.npmjs.com/trusted-publishers
