### PR TITLE
fix(ci): ensure minimal required npm version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,12 @@ jobs:
                   node-version: 20
                   cache: "pnpm"
 
+            # Minimum required version for npm publish with OIDC Support
+            # https://docs.npmjs.com/trusted-publishers
+            - run: |
+                npm install npm@latest
+                npm version
+
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
               with:


### PR DESCRIPTION
This pull request updates the release workflow to ensure that the latest version of `npm` is installed before publishing, which is necessary for OIDC support. This change helps maintain compatibility with npm's trusted publisher requirements.

Workflow improvements:

* Added a step to install the latest version of `npm` and print the version before publishing, ensuring OIDC support as required by npm's trusted publishers documentation. (.github/workflows/release.yaml)