### PR TITLE
fix(ci): install npm globally

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,8 @@ jobs:
             # Minimum required version for npm publish with OIDC Support
             # https://docs.npmjs.com/trusted-publishers
             - run: |
-                npm install npm@latest
-                npm version
+                npm install -g npm@latest
+                npm --version
 
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow for releases. The change ensures that the latest version of `npm` is installed globally, which is necessary for publishing with OIDC support.

* Updated the `release.yaml` workflow to install the latest `npm` globally using `npm install -g npm@latest` and verified the version with `npm --version`.