### PR TITLE
sdk: chore/bump nitro to v0.5

### DIFF
--- a/.changeset/wild-stars-argue.md
+++ b/.changeset/wild-stars-argue.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+bump nitro to v0.5

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -179,7 +179,11 @@ COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitro /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitroctl /usr/local/bin/
 COPY skel/ /
-RUN mkdir -p /run/nitro && chown -R cartesi:cartesi /run/nitro
+RUN <<EOF
+mkdir -p /run/nitro
+chown -R cartesi:cartesi /run/nitro
+chmod +x /etc/nitro/*/run
+EOF
 
 USER cartesi
 

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -53,14 +53,12 @@ RUN curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDR
     | tar -zx -C /usr/local/bin
 
 ################################################################################
-# nitro installer
+# nitro builder
 FROM builder AS nitro
 ARG NITRO_VERSION
 WORKDIR /usr/local/src
-ADD https://github.com/leahneukirchen/nitro.git#v${NITRO_VERSION} /usr/local/src
-RUN <<EOF
-make
-EOF
+ADD https://github.com/leahneukirchen/nitro.git#${NITRO_VERSION} /usr/local/src
+RUN make
 
 ################################################################################
 # build msquashfs-tools

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -19,7 +19,7 @@ target "default" {
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.8"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"
-    NITRO_VERSION                     = "0.5"
+    NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:8a56bef4c60bef3d26193cb9d810fce93def8fd0c459f4a9b14240fbd7559a1d"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -19,7 +19,7 @@ target "default" {
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.8"
     FOUNDRY_VERSION                   = "1.2.1"
     GO_MIGRATE_VERSION                = "4.18.2"
-    NITRO_VERSION                     = "0.3"
+    NITRO_VERSION                     = "0.5"
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:8a56bef4c60bef3d26193cb9d810fce93def8fd0c459f4a9b14240fbd7559a1d"


### PR DESCRIPTION
This pull request updates the Cartesi SDK to use Nitro version 0.5 and makes related adjustments to the Docker build process. The main changes are focused on upgrading dependencies and ensuring compatibility with the new Nitro version.

Dependency and version updates:

* Bumped the Nitro dependency to version 0.5 in the SDK package and Docker build configuration (`.changeset/wild-stars-argue.md`, `packages/sdk/docker-bake.hcl`). [[1]](diffhunk://#diff-324342d84b1d902593d560fc847270016785a9849550e51adfd255565976c9b1R1-R5) [[2]](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL22-R22)

Dockerfile improvements for Nitro compatibility:

* Updated the `packages/sdk/Dockerfile` to set executable permissions on Nitro run scripts and improved the setup commands for the `/run/nitro` directory to ensure proper ownership and permissions.