### PR TITLE
chore(sdk): bump su-exec to v0.3

### DIFF
--- a/.changeset/fair-cougars-buy.md
+++ b/.changeset/fair-cougars-buy.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": minor
+---
+
+bump su-exec to v0.3

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -37,11 +37,26 @@ EOF
 
 ################################################################################
 # su-exec builder
-FROM builder AS su-exec
+FROM base AS su-exec
 ARG SU_EXEC_VERSION
-WORKDIR /usr/local/src
-ADD https://github.com/ncopa/su-exec.git#v${SU_EXEC_VERSION} /usr/local/src
-RUN make
+ARG TARGETARCH
+WORKDIR /usr/local/bin
+RUN <<EOF
+ARCH=${TARGETARCH}
+
+if [ "$ARCH" = "amd64" ]; then
+    ARCH="x86_64"
+fi
+
+curl -fsSL https://github.com/ncopa/su-exec/releases/download/v${SU_EXEC_VERSION}/su-exec-static-v${SU_EXEC_VERSION}-${ARCH} \
+  -o su-exec
+case "${TARGETARCH}" in
+    amd64) echo "675e7b454ad96e7631029f0b71c9ad5a6c23b553a8952ed528de1e591ca7cef0 su-exec" | sha256sum --check ;;
+    arm64) echo "a08773d4af76a30371f8d1c93e86e8ac2b0379c9e75dce9d694c5059b0544909 su-exec" | sha256sum --check ;;
+    *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
+esac
+chmod +x su-exec
+EOF
 
 ################################################################################
 # foundry installer
@@ -132,7 +147,7 @@ chown cartesi:cartesi /var/lib/cartesi-rollups-node/snapshots
 cartesi-rollups-node --version
 EOF
 
-COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
+COPY --from=su-exec /usr/local/bin/su-exec /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitro /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitroctl /usr/local/bin/
 COPY skel/ /

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -22,7 +22,7 @@ target "default" {
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:ecebd237d9aaf83112427807848bc41ba6bd4df8a2f6936e09f7db1813609625"
     SQUASHFS_TOOLS_VERSION            = "99d23a31b471433c51e9c145aeba2ab1536e34df" # 4.7.2
-    SU_EXEC_VERSION                   = "0.2"
+    SU_EXEC_VERSION                   = "0.3"
     XGENEXT2_VERSION                  = "1.5.6"
   }
 }


### PR DESCRIPTION
 - use `su-exec` binary release instead of building it
 - verify binary checksum
