### PR TITLE
chore(sdk): bump baseimage to debian:trixie-20251229-slim

### DIFF
--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -8,7 +8,7 @@ target "default" {
   args = {
     ALTO_VERSION                      = "1.2.5"
     ALTO_PACKAGE_VERSION              = "0.0.18"
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20251117-slim@sha256:9812458f2932ede726468ba07bcb9e51bceb1f0c7f16ee30baa789ccee7cc202"
+    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20251229-slim@sha256:4bcb9db66237237d03b55b969271728dd3d955eaaa254b9db8a3db94550b1885"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.8"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
@@ -20,7 +20,7 @@ target "default" {
     NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "22.15.1"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:ecebd237d9aaf83112427807848bc41ba6bd4df8a2f6936e09f7db1813609625"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:bac8128cd62a35471a1e97966861aa2ac88c8d2f408767a425ae70695a607c99"
     SQUASHFS_TOOLS_VERSION            = "99d23a31b471433c51e9c145aeba2ab1536e34df" # 4.7.2
     SU_EXEC_VERSION                   = "0.3"
     XGENEXT2_VERSION                  = "1.5.6"


### PR DESCRIPTION
This pull request updates the base images used for building the SDK in the `docker-bake.hcl` configuration. The changes ensure the build uses the latest available versions of the Debian and Postgres images, which improves security and stability.

Base image updates:

* Updated the `CARTESI_BASE_IMAGE` to use a newer Debian Trixie slim image (`trixie-20251229-slim`) with a new SHA256 digest for improved security and compatibility.
* Updated the `POSTGRES_BASE_IMAGE` to a newer version of the Postgres 17 Trixie image with an updated SHA256 digest for enhanced reliability.