### PR TITLE
Optional authority deployment

### DIFF
--- a/.changeset/cute-houses-occur.md
+++ b/.changeset/cute-houses-occur.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+optional authority deployment

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -170,6 +170,12 @@ export const createRunCommand = () => {
         .description("Run a local cartesi node for the application.")
         .addOption(
             new Option(
+                "--authority",
+                "deploy application with authority consensus",
+            ).default(false),
+        )
+        .addOption(
+            new Option(
                 "--block-time <number>",
                 "interval between blocks (in seconds)",
             )
@@ -227,6 +233,7 @@ export const createRunCommand = () => {
         .option("-v, --verbose", "verbose output", false)
         .action(async (options, program) => {
             const {
+                authority,
                 blockTime,
                 cpus,
                 defaultBlock,
@@ -318,7 +325,7 @@ export const createRunCommand = () => {
                 epochLength,
                 log,
                 projectName,
-                prt: true,
+                prt: !authority,
             });
             await shutdown();
         });


### PR DESCRIPTION
Create an `--authority` option to deploy application as authority, instead of the default PRT behavior.
The idea is to favor PRT instead of authority.
