### PR TITLE
feat(cli): bump explorer

### DIFF
--- a/.changeset/four-dragons-write.md
+++ b/.changeset/four-dragons-write.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+bump explorer

--- a/apps/cli/src/compose/docker-compose-explorer.yaml
+++ b/apps/cli/src/compose/docker-compose-explorer.yaml
@@ -39,7 +39,7 @@ configs:
 
 services:
     explorer_api:
-        image: cartesi/rollups-explorer-api:1.0.0
+        image: cartesi/rollups-explorer-api:1.1.0
         environment:
             <<: *explorer_db_env
             GQL_PORT: 4350
@@ -65,7 +65,7 @@ services:
                 condition: service_healthy
 
     squid_processor:
-        image: cartesi/rollups-explorer-api:1.0.0
+        image: cartesi/rollups-explorer-api:1.1.0
         environment:
             <<: *explorer_db_env
             CHAIN_IDS: ${CARTESI_BLOCKCHAIN_ID:-13370}
@@ -78,7 +78,7 @@ services:
                 condition: service_healthy
 
     explorer:
-        image: cartesi/rollups-explorer:1.3.3
+        image: cartesi/rollups-explorer:1.4.0
         environment:
             NODE_RPC_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/anvil"
             EXPLORER_API_URL: "http://127.0.0.1:${CARTESI_LISTEN_PORT:-6751}/explorer-api/graphql"


### PR DESCRIPTION
Updating explorer images with version that support contracts 2.1