### PR TITLE
ci: setup npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
             - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
 
             # Minimum required version for npm publish with OIDC Support


### PR DESCRIPTION
npm will still be used by `npm publish` because of [OIDC publishing support](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).