### PR TITLE
Use docker hardened images

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -143,8 +143,15 @@ jobs:
         permissions:
             contents: read
             packages: read
-        name: trivy-${{ matrix.target }}
+        name: docker-scout-${{ matrix.target }}
         steps:
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Login to DockerHub
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -158,6 +158,7 @@ jobs:
               with:
                 command: quickview,cves
                 image: ghcr.io/cartesi/${{ matrix.target }}:pr-${{ github.event.pull_request.number }}
+                ignore-base: true
                 ignore-unchanged: true
                 only-severities: critical,high
                 github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -110,6 +110,7 @@ jobs:
                       *.cache-from=type=gha
                       *.cache-to=type=gha,mode=max
                   push: true
+                  sbom: true
 
             - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
             - name: Build and push (depot)
@@ -129,8 +130,9 @@ jobs:
                       ./docker-metadata-rollups-runtime/docker-metadata-action-bake.json
                       ./docker-metadata-rollups-database/docker-metadata-action-bake.json
                   push: true
+                  sbom: true
 
-    trivy:
+    scout:
         runs-on: ubuntu-latest
         needs:
             - build
@@ -143,61 +145,30 @@ jobs:
             packages: read
         name: trivy-${{ matrix.target }}
         steps:
-            - name: Download all docker-metadata artifacts
+            - name: Download bake metadata
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
               with:
-                  pattern: docker-metadata-*
-                  path: packages/sdk/
+                name: bake-metadata
 
-            - name: Trivy Setup
-              uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.0
+            - name: Get image digest
+              id: image-ref
+              run: |
+                DIGEST=$(jq -r '."${{ matrix.target }}"["containerimage.digest"]' bake-metadata.json)
+                echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+            - name: Login to DockerHub
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
-                cache: true
-                version: v0.69.1
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            - name: Collect image references
-              id: images
-              run: |
-                  set -euo pipefail
-
-                  mapfile -t IMAGES < <(
-                    jq -r '.. | .tags? // empty | .[]?' \
-                      packages/sdk/docker-metadata-${{ matrix.target }}/docker-metadata-action-bake.json \
-                      | awk 'NF > 0' \
-                      | sort -u
-                  )
-
-                  if [ "${#IMAGES[@]}" -eq 0 ]; then
-                    echo "No image tags found in docker metadata artifacts."
-                    exit 0
-                  fi
-
-                  {
-                    echo "images<<EOF"
-                    printf '%s\n' "${IMAGES[@]}"
-                    echo "EOF"
-                  } >> "$GITHUB_OUTPUT"
-
-            - name: Scan images with Trivy
-              if: ${{ steps.images.outputs.images != '' }}
-              run: |
-                  set -euo pipefail
-
-                  while IFS= read -r image; do
-                    [ -z "$image" ] && continue
-                    echo "Scanning $image"
-                    {
-                        echo "<details><summary><strong>Trivy image scan : ${{ matrix.target }} </strong></summary><pre lang="shell"><code>"
-
-                        trivy image                     \
-                            --scanners vuln             \
-                            --format table              \
-                            --report summary            \
-                            --severity HIGH,CRITICAL    \
-                            --ignore-unfixed            \
-                            --exit-code 1               \
-                            "$image"
-
-                        echo "</code></pre></details><hr>"
-                    } >> $GITHUB_STEP_SUMMARY
-                  done <<< "${{ steps.images.outputs.images }}"
+            - name: Docker Scout
+              id: docker-scout
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
+              with:
+                command: quickview,cves
+                image: ghcr.io/cartesi/${{ matrix.target }}@${{ steps.image-ref.outputs.digest }}
+                ignore-unchanged: true
+                only-severities: critical,high
+                github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -145,7 +145,7 @@ jobs:
             packages: read
         name: trivy-${{ matrix.target }}
         steps:
-            - name: Download docker-metadata-${{ target.matrix }} artifact
+            - name: Download docker-metadata-${{ matrix.target }} artifact
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
               with:
                 name: docker-metadata-${{ matrix.target }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -22,7 +22,7 @@ jobs:
     meta:
         runs-on: ubuntu-latest
         strategy:
-            matrix:
+            matrix: &target-matrix
                 target:
                     - rollups-database
                     - rollups-runtime
@@ -50,7 +50,7 @@ jobs:
                       type=ref,event=pr
 
             - name: Upload bake definition file
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
                   name: docker-metadata-${{ matrix.target }}
                   path: ${{ steps.meta.outputs.bake-file }}
@@ -63,7 +63,7 @@ jobs:
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Download all docker-metadata artifacts
-              uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+              uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
               with:
                   path: packages/sdk/
 
@@ -129,3 +129,75 @@ jobs:
                       ./docker-metadata-rollups-runtime/docker-metadata-action-bake.json
                       ./docker-metadata-rollups-database/docker-metadata-action-bake.json
                   push: true
+
+    trivy:
+        runs-on: ubuntu-latest
+        needs:
+            - build
+            - meta
+        strategy:
+            fail-fast: false
+            matrix: *target-matrix
+        permissions:
+            contents: read
+            packages: read
+        name: trivy-${{ matrix.target }}
+        steps:
+            - name: Download all docker-metadata artifacts
+              uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+              with:
+                  pattern: docker-metadata-*
+                  path: packages/sdk/
+
+            - name: Trivy Setup
+              uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.0
+              with:
+                cache: true
+                version: v0.69.1
+
+            - name: Collect image references
+              id: images
+              run: |
+                  set -euo pipefail
+
+                  mapfile -t IMAGES < <(
+                    jq -r '.. | .tags? // empty | .[]?' \
+                      packages/sdk/docker-metadata-${{ matrix.target }}/docker-metadata-action-bake.json \
+                      | awk 'NF > 0' \
+                      | sort -u
+                  )
+
+                  if [ "${#IMAGES[@]}" -eq 0 ]; then
+                    echo "No image tags found in docker metadata artifacts."
+                    exit 0
+                  fi
+
+                  {
+                    echo "images<<EOF"
+                    printf '%s\n' "${IMAGES[@]}"
+                    echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Scan images with Trivy
+              if: ${{ steps.images.outputs.images != '' }}
+              run: |
+                  set -euo pipefail
+
+                  while IFS= read -r image; do
+                    [ -z "$image" ] && continue
+                    echo "Scanning $image"
+                    {
+                        echo "<details><summary><strong>Trivy image scan : ${{ matrix.target }} </strong></summary><pre lang="shell"><code>"
+
+                        trivy image                     \
+                            --scanners vuln             \
+                            --format table              \
+                            --report summary            \
+                            --severity HIGH,CRITICAL    \
+                            --ignore-unfixed            \
+                            --exit-code 1               \
+                            "$image"
+
+                        echo "</code></pre></details><hr>"
+                    } >> $GITHUB_STEP_SUMMARY
+                  done <<< "${{ steps.images.outputs.images }}"

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -83,6 +83,13 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Login to Docker Hardened Registry
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              with:
+                  registry: dhi.io
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build and push
               uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -145,17 +145,6 @@ jobs:
             packages: read
         name: trivy-${{ matrix.target }}
         steps:
-            - name: Download docker-metadata-${{ matrix.target }} artifact
-              uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-              with:
-                name: docker-metadata-${{ matrix.target }}
-
-            - name: Get image digest
-              id: image-ref
-              run: |
-                DIGEST=$(jq -r '."${{ matrix.target }}"["containerimage.digest"]' ./docker-metadata-${{ matrix.target }}/docker-metadata-action-bake.json)
-                echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
             - name: Login to DockerHub
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
@@ -168,7 +157,7 @@ jobs:
               uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
               with:
                 command: quickview,cves
-                image: ghcr.io/cartesi/${{ matrix.target }}@${{ steps.image-ref.outputs.digest }}
+                image: ghcr.io/cartesi/${{ matrix.target }}:pr-${{ github.event.pull_request.number }}
                 ignore-unchanged: true
                 only-severities: critical,high
                 github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -145,15 +145,15 @@ jobs:
             packages: read
         name: trivy-${{ matrix.target }}
         steps:
-            - name: Download bake metadata
+            - name: Download docker-metadata-${{ target.matrix }} artifact
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
               with:
-                name: bake-metadata
+                name: docker-metadata-${{ matrix.target }}
 
             - name: Get image digest
               id: image-ref
               run: |
-                DIGEST=$(jq -r '."${{ matrix.target }}"["containerimage.digest"]' bake-metadata.json)
+                DIGEST=$(jq -r '."${{ matrix.target }}"["containerimage.digest"]' ./docker-metadata-${{ matrix.target }}/docker-metadata-action-bake.json)
                 echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
             - name: Login to DockerHub

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -127,6 +127,7 @@ ARG TELEGRAF_VERSION
 ARG TARGETARCH
 WORKDIR /tmp
 RUN <<EOF
+mkdir -p /usr/local/bin
 curl -fsSL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${TARGETARCH}.tar.gz \
     -o ./telegraf.tar.gz;
 case "${TARGETARCH}" in
@@ -151,8 +152,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 apt-get install -y --no-install-recommends \
     libslirp0 \
-    lua5.4 \
-    passwd
+    lua5.4
 
 # create cartesi user
 useradd \
@@ -165,7 +165,6 @@ useradd \
     --user-group \
     cartesi
 
-apt-get remove -y --purge passwd
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 ARG CARTESI_BASE_IMAGE
-ARG POSTGRES_BASE_IMAGE
+ARG POSTGRES_BASE_BUILD_IMAGE
+ARG POSTGRES_BASE_RUNTIME_IMAGE
 ARG NODE_VERSION
 
 ################################################################################
@@ -212,7 +213,7 @@ USER cartesi
 
 ################################################################################
 # postgresql initdb
-FROM ${POSTGRES_BASE_IMAGE} AS postgresql-initdb
+FROM ${POSTGRES_BASE_BUILD_IMAGE} AS postgresql-initdb
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -245,8 +246,12 @@ RUN /usr/local/bin/docker-ensure-initdb.sh postgres
 
 ################################################################################
 # rollups-database image
-FROM ${POSTGRES_BASE_IMAGE} AS rollups-database
-COPY --from=postgresql-initdb /var/lib/postgresql/data /var/lib/postgresql/data
+FROM ${POSTGRES_BASE_RUNTIME_IMAGE} AS rollups-database
+ARG POSTGRES_MAJOR_VERSION
+COPY --from=postgresql-initdb \
+    --chown=postgres:postgres \
+    --chmod=750 \
+    /var/lib/postgresql/data /var/lib/postgresql/${POSTGRES_MAJOR_VERSION}/data
 
 ################################################################################
 # alto build

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -66,6 +66,7 @@ FROM base AS foundry
 ARG FOUNDRY_VERSION
 ARG TARGETARCH
 ARG TARGETOS
+WORKDIR /usr/local/bin
 RUN <<EOF
 mkdir -p /usr/local/bin
 curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz \
@@ -103,6 +104,7 @@ FROM base AS tini
 ARG TINI_VERSION
 ARG TARGETARCH
 RUN <<EOF
+mkdir -p /usr/local/bin
 case "${TARGETARCH}" in
     amd64)
         curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
@@ -149,12 +151,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 apt-get install -y --no-install-recommends \
     libslirp0 \
-    lua5.4
-rm -rf /var/lib/apt/lists/*
-EOF
+    lua5.4 \
+    passwd
 
-RUN <<EOF
-set -e
+# create cartesi user
 useradd \
     --comment "cartesi user" \
     --no-create-home \
@@ -164,6 +164,9 @@ useradd \
     --uid 102 \
     --user-group \
     cartesi
+
+apt-get remove -y --purge passwd
+rm -rf /var/lib/apt/lists/*
 EOF
 
 # Install cartesi-machine emulator
@@ -323,9 +326,7 @@ apt-get install -y --no-install-recommends \
     liblzo2-2 \
     libslirp0 \
     locales \
-    lua5.4 \
-    xxd \
-    xz-utils
+    xxd
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -8,7 +8,7 @@ target "default" {
   args = {
     ALTO_VERSION                      = "1.2.7"
     ALTO_PACKAGE_VERSION              = "0.0.20"
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20260223-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421"
+    CARTESI_BASE_IMAGE                = "dhi.io/debian-base:bookworm-dev@sha256:b39f7bdc82227f2bdf985dc53e6a051047f0f07c346b58966c09b8d3fe557224"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.11"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -20,7 +20,9 @@ target "default" {
     NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "24.14.0"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-bookworm@sha256:ed736a0232f124704e442614fa13a042c4471b76af79dc74ddcf72023e351ed2"
+    POSTGRES_MAJOR_VERSION            = "17"
+    POSTGRES_BASE_BUILD_IMAGE         = "docker.io/library/postgres:17-bookworm@sha256:c141933f34b7fd6819478e1fa2106c262999c0af1e2cdbf0b4727b53fb194a77"
+    POSTGRES_BASE_RUNTIME_IMAGE       = "dhi.io/postgres:17-debian12@sha256:2e24c142f136f29d8c08d0f3a973462302425bd1b52e337908df4f9a0895bf55"
     SQUASHFS_TOOLS_VERSION            = "bad1d213ab6df587d6fa0ef7286180fbf7b86167" # 4.7.4
     SU_EXEC_VERSION                   = "0.3"
     TELEGRAF_VERSION                  = "1.38.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "version": "0.12.0-alpha.37",
     "scripts": {
-        "build": "docker buildx bake --load --metadata-file=build.json"
+        "build": "docker buildx bake --load --metadata-file=build.json",
+        "digest-update": "../../.github/scripts/update-image-digests.sh ./docker-bake.hcl"
     }
 }


### PR DESCRIPTION
This pull request updates the SDK's Docker build process and related configuration to improve image security and flexibility. The main changes include switching to hardened base images from a private registry, splitting PostgreSQL images into build and runtime variants, and refining the Dockerfile to streamline dependencies and user creation.

**Container base image and registry updates:**

- Switched the default Debian base image from Docker Hub to a hardened image hosted on `dhi.io` for improved security (`packages/sdk/docker-bake.hcl`).
- Added a new GitHub Actions workflow step to log in to the Docker Hardened Registry (`dhi.io`) before building images (`.github/workflows/sdk.yaml`).

**PostgreSQL image improvements:**

- Split the PostgreSQL base image into separate build and runtime images, using the official image for building and a hardened runtime image from `dhi.io` for production, with configurable major version support (`packages/sdk/docker-bake.hcl`, `packages/sdk/Dockerfile`). [[1]](diffhunk://#diff-f31033306f300af23520856c404681eb6cbe45d9f28ce0f28abb24fcae811e5bL23-R25) [[2]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL172-R175) [[3]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feL205-R224)
- Updated the data directory copy step to set correct ownership and permissions, and to use the major version in the path, aligning with best practices for PostgreSQL containers (`packages/sdk/Dockerfile`).

**Dockerfile dependency and user management:**

- Refined the Dockerfile to install only necessary packages for user creation (`passwd`), then remove them immediately after use to reduce image size and attack surface (`packages/sdk/Dockerfile`). [[1]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR112-R115) [[2]](diffhunk://#diff-fbbb6309bd1c5bde85dc9baab5c5c1ef5af52fedb5e3fd28cecf37916d3ef1feR125-R127)
- Cleaned up unnecessary packages in the final image, removing `lua5.4` and `xz-utils` from the runtime dependencies (`packages/sdk/Dockerfile`).

**Build process enhancements:**

- Ensured the `/usr/local/bin` directory exists before extracting binaries, improving reliability during the build (`packages/sdk/Dockerfile`).
- Changed the way the `forge` binary is included, copying it from a prior build stage instead of downloading it again, which improves build caching and consistency (`packages/sdk/Dockerfile`).