### PR TITLE
fix(cli): cpp template create

### DIFF
--- a/.changeset/upset-snails-attack.md
+++ b/.changeset/upset-snails-attack.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+fix command create --template=cpp was conflicting with cpp-low-level

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -33,7 +33,7 @@ export const download = async (
         filter: (header) => {
             // remove first path segment
             const pathname = header.name.split("/").splice(1).join("/");
-            return pathname.startsWith(template);
+            return pathname.startsWith(`${template}/`);
         },
         map: (header) => {
             // remove first path segment


### PR DESCRIPTION
Creating a cpp template was fgailing beacuse it was conflicting with the cpp-low-level.

Made the match more restrict to the directory name.
