### PR TITLE
chore(cli): enable docker-init for rollups_node service

### DIFF
--- a/.changeset/rare-mugs-smell.md
+++ b/.changeset/rare-mugs-smell.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+enable docker-init for rollups_node service

--- a/apps/cli/src/compose/node.ts
+++ b/apps/cli/src/compose/node.ts
@@ -41,6 +41,7 @@ const service = (options: ServiceOptions): Service => {
 
     return {
         image: `cartesi/rollups-runtime:${imageTag}`,
+        init: true,
         depends_on: {
             database: { condition: "service_healthy" },
             anvil: { condition: "service_healthy" },


### PR DESCRIPTION
When the docker-init is not used, every input sent and processed leaves a zombie process.

```shell
➜  my-go-dapp docker compose -p my-go-dapp exec -ti rollups_node ps ux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cartesi        1  0.2  0.0 2742860 45700 ?       Ssl  18:06   0:00 cartesi-rollups-node
cartesi       50  6.5  0.0      0     0 ?        Z    18:06   0:09 [cartesi-jsonrpc] <defunct>
cartesi     1119  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     2050  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     2947  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     3876  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     4773  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     5699  0.0  0.0      0     0 ?        Z    18:07   0:00 [cartesi-jsonrpc] <defunct>
cartesi     6616  0.0  0.0      0     0 ?        Z    18:08   0:00 [cartesi-jsonrpc] <defunct>
cartesi     7513  0.0  0.0      0     0 ?        Z    18:08   0:00 [cartesi-jsonrpc] <defunct>
cartesi     8435  0.0  0.0      0     0 ?        Z    18:08   0:00 [cartesi-jsonrpc] <defunct>
cartesi     9344  0.0  0.0      0     0 ?        Z    18:08   0:00 [cartesi-jsonrpc] <defunct>
```

After enabling the docker-init, this is not an issue anymore:

```shell
➜  my-go-dapp docker compose -p my-go-dapp exec  -ti rollups_node ps ux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cartesi        1  0.0  0.0   1068   780 ?        Ss   18:10   0:00 /sbin/docker-init -- cartesi-rollups-node
cartesi        7  0.5  0.0 2742604 43024 ?       Sl   18:10   0:00 cartesi-rollups-node
cartesi     2941  1.9  0.2 1337364 152092 ?      S    18:11   0:00 cartesi-jsonrpc-machine --server-fd=21
```
