### PR TITLE
feat(cli): default to authority consensus

### DIFF
--- a/.changeset/great-jeans-bake.md
+++ b/.changeset/great-jeans-bake.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+make Authority the default consensus mode

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -194,8 +194,8 @@ export const createRunCommand = () => {
         .description("Run a local cartesi node for the application.")
         .addOption(
             new Option(
-                "--authority",
-                "deploy application with authority consensus",
+                "--prt",
+                "deploy application with PRT consensus",
             ).default(false),
         )
         .addOption(
@@ -264,7 +264,7 @@ export const createRunCommand = () => {
         .option("-v, --verbose", "verbose output", false)
         .action(async (options, program) => {
             const {
-                authority,
+                prt,
                 blockTime,
                 cpus,
                 defaultBlock,
@@ -313,6 +313,7 @@ export const createRunCommand = () => {
                 memory,
                 port,
                 projectName,
+                prt,
                 runtimeVersion,
                 services,
                 verbose,
@@ -342,7 +343,6 @@ export const createRunCommand = () => {
             // deploy the application
             let deployment: RollupsDeployment | undefined;
             let salt = 0;
-            const prt = !authority;
             const hash = getMachineHash();
             if (hash) {
                 deployment = await deploy({

--- a/apps/cli/src/compose/node.ts
+++ b/apps/cli/src/compose/node.ts
@@ -18,6 +18,7 @@ type ServiceOptions = {
     memory?: number;
     mnemonic?: string;
     imageTag?: string;
+    prt?: boolean;
 };
 
 // Rollups Node service
@@ -31,12 +32,16 @@ const service = (options: ServiceOptions): Service => {
     const mnemonic =
         options.mnemonic ??
         "test test test test test test test test test test test junk";
+    const prt = options.prt ?? false;
     const chainId = (options.forkChainId ??
         31337) as keyof typeof daveAppFactoryAddress;
 
-    const chainDaveAppFactoryAddress = daveAppFactoryAddress[chainId];
-    if (!chainDaveAppFactoryAddress) {
-        throw new Error(`Unsupported fork chain ${chainId}`);
+    let chainDaveAppFactoryAddress: string | undefined;
+    if (prt) {
+        chainDaveAppFactoryAddress = daveAppFactoryAddress[chainId];
+        if (!chainDaveAppFactoryAddress) {
+            throw new Error(`Unsupported fork chain ${chainId}`);
+        }
     }
 
     return {
@@ -72,8 +77,10 @@ const service = (options: ServiceOptions): Service => {
             CARTESI_BLOCKCHAIN_HTTP_ENDPOINT: "http://anvil:8545",
             CARTESI_BLOCKCHAIN_ID: anvil.id.toString(),
             CARTESI_BLOCKCHAIN_WS_ENDPOINT: "ws://anvil:8545",
-            CARTESI_CONTRACTS_DAVE_APP_FACTORY_ADDRESS:
-                chainDaveAppFactoryAddress,
+            ...(chainDaveAppFactoryAddress && {
+                CARTESI_CONTRACTS_DAVE_APP_FACTORY_ADDRESS:
+                    chainDaveAppFactoryAddress,
+            }),
             CARTESI_CONTRACTS_INPUT_BOX_ADDRESS: inputBoxAddress,
             CARTESI_CONTRACTS_SELF_HOSTED_APPLICATION_FACTORY_ADDRESS:
                 selfHostedApplicationFactoryAddress,

--- a/apps/cli/src/exec/rollups.ts
+++ b/apps/cli/src/exec/rollups.ts
@@ -248,6 +248,7 @@ export const startEnvironment = async (options: {
     memory?: number;
     port: number;
     projectName: string;
+    prt?: boolean;
     runtimeVersion: string;
     services: string[];
     verbose: boolean;
@@ -262,6 +263,7 @@ export const startEnvironment = async (options: {
         memory,
         port,
         projectName,
+        prt,
         runtimeVersion,
         services,
         verbose,
@@ -292,6 +294,7 @@ export const startEnvironment = async (options: {
             imageTag: runtimeVersion,
             logLevel: verbose ? "debug" : "info",
             memory,
+            prt,
         }),
         proxy({ imageTag: "v3.3.4", port }),
     ];


### PR DESCRIPTION
Since the focus on the SDK stability is with Authority consensus, we should make this the default, and use `--prt` when necessary.