### PR TITLE
chore(devnet): Bump PRT and Rollups to latest versions

### DIFF
--- a/.changeset/loud-states-change.md
+++ b/.changeset/loud-states-change.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+Upgrade PRT to v2.1.0, rollups contract to v2.2.0 and update url as dave artefacts filename changed.

--- a/packages/devnet/build.ts
+++ b/packages/devnet/build.ts
@@ -16,8 +16,8 @@ import * as anvil from "./anvil";
 import { downloadAndExtract } from "./download";
 
 const ANVIL_VERSION = "1.4.3";
-const ROLLUPS_VERSION = "2.1.1";
-const PRT_VERSION = "2.0.1";
+const ROLLUPS_VERSION = "2.2.0";
+const PRT_VERSION = "2.1.0";
 const CANNON_VERSION = "2.0.0";
 
 const supportedChains = {
@@ -36,11 +36,11 @@ const supportedChains = {
  */
 const dependencies: ListrTask[] = [
     {
-        url: `https://github.com/cartesi/dave/releases/download/v${PRT_VERSION}/cartesi-rollups-prt-anvil-v${ANVIL_VERSION}.tar.gz`,
+        url: `https://github.com/cartesi/dave/releases/download/v${PRT_VERSION}/cartesi-rollups-prt-${PRT_VERSION}-anvil-v${ANVIL_VERSION}.tar.gz`,
         destination: "build",
     },
     {
-        url: `https://github.com/cartesi/dave/releases/download/v${PRT_VERSION}/cartesi-rollups-prt-contract-artifacts.tar.gz`,
+        url: `https://github.com/cartesi/dave/releases/download/v${PRT_VERSION}/cartesi-rollups-prt-${PRT_VERSION}-contract-artifacts.tar.gz`,
         destination: "out",
         stripComponents: 3,
     },


### PR DESCRIPTION
# Summary
Upgrade the PRT to version v2.1.0 and Rollups contracts to v2.2.0. Also, a small fix to the URL to download the Dave release artefacts.

The following contracts have a new address:

* `DaveAppFactory`
* `AuthorityFactory`
* `QuorumFactory `
* `SelfHostedApplicationFactory `