### PR TITLE
chore: Bump PRT related configs to use v2.1.1.

### DIFF
--- a/.changeset/curvy-pets-look.md
+++ b/.changeset/curvy-pets-look.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+Bump prt to version 2.1.1

--- a/packages/devnet/build.ts
+++ b/packages/devnet/build.ts
@@ -17,8 +17,8 @@ import { downloadAndExtract } from "./download";
 
 const ANVIL_VERSION = "1.4.3";
 const ROLLUPS_VERSION = "2.2.0";
-const PRT_VERSION = "2.1.0";
-const CANNON_VERSION = "2.0.0";
+const PRT_VERSION = "2.1.1";
+const CANNON_VERSION = "2.1.1";
 
 const supportedChains = {
     arbitrum,


### PR DESCRIPTION
# Summary
code changes to upgrade devnet package to use PRT version **v2.1.1** 

## Dependencies 

- [x] Release artefacts on dave repository 
- [x] Release dave v2.1.1 on cannon package `cartesi-dave-app-factory` 

Once the dependencies are green, I will apply a fixup in the first commit and change the PR to ready-to-review.