### PR TITLE
feat(sdk): add telegraf to rollups-runtime

### DIFF
--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -118,6 +118,25 @@ tini --version
 EOF
 
 ################################################################################
+# install telegraf
+FROM base AS telegraf
+ARG TELEGRAF_VERSION
+ARG TARGETARCH
+WORKDIR /tmp
+RUN <<EOF
+curl -fsSL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${TARGETARCH}.tar.gz \
+    -o ./telegraf.tar.gz;
+case "${TARGETARCH}" in
+    amd64) echo "57e6d733de44335127c06d9d9099c9dee7307beff992783438ce38b9ba1b8e5e /tmp/telegraf.tar.gz" | sha256sum --check ;;
+    arm64) echo "d42aa06b113f15fdc14775a2d1971e31a0adb82a6e0da28e40a17e819ddaeb06 /tmp/telegraf.tar.gz" | sha256sum --check ;;
+    *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
+esac
+tar -xvzf /tmp/telegraf.tar.gz -C / --strip-components=2 ./telegraf-${TELEGRAF_VERSION}/usr/bin/telegraf
+cp /usr/bin/telegraf /usr/local/bin/telegraf
+telegraf --version
+EOF
+
+################################################################################
 # cartesi rollups-runtime target
 FROM base AS rollups-runtime
 ARG CARTESI_MACHINE_EMULATOR_VERSION
@@ -181,6 +200,7 @@ COPY --from=su-exec /usr/local/bin/su-exec /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitro /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitroctl /usr/local/bin/
 COPY --from=tini /usr/local/bin/tini /usr/local/bin/
+COPY --from=telegraf /usr/local/bin/telegraf /usr/local/bin/
 COPY skel/ /
 RUN <<EOF
 mkdir -p /run/nitro

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -23,6 +23,7 @@ target "default" {
     POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:9ba47fa6d1c34e9cc4c1758640e7774a9b73ea0fba891f14088321ba7561d253"
     SQUASHFS_TOOLS_VERSION            = "bad1d213ab6df587d6fa0ef7286180fbf7b86167" # 4.7.4
     SU_EXEC_VERSION                   = "0.3"
+    TELEGRAF_VERSION                  = "1.38.0"
     TINI_VERSION                      = "0.19.0"
     XGENEXT2_VERSION                  = "1.5.6"
   }


### PR DESCRIPTION
When deploying a rollups-node using the cartesi/rollups-runtime container image, it's usefull to have some way to collect metrics about the environment.

I propose we add telegraf as an option inside the image, just like we have other auxiliary tools to supervise the services like `nitro` and `tini`.

Those who will use telegraf, should be responsible to add the necessary configuration.

From the Cartesi Infra side, we're already using and having to add telegraf everywhere, so having this as part of the runtime image would save some time.