### PR TITLE
fix(sdk): Update file permission for linux.bin

### DIFF
--- a/.changeset/eighty-jobs-show.md
+++ b/.changeset/eighty-jobs-show.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Add read permission to group and others. Modified file /usr/share/cartesi-machine/linux.bin

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -375,7 +375,7 @@ COPY entrypoint.sh /usr/local/bin/
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/
 COPY --from=squashfs-tools /usr/local/src/squashfs-tools/mksquashfs /usr/local/bin/
-COPY --from=kernel-image /usr/share/cartesi-machine/images/linux.bin /usr/share/cartesi-machine/images/linux.bin
+COPY --from=kernel-image --chmod=644 /usr/share/cartesi-machine/images/linux.bin /usr/share/cartesi-machine/images/linux.bin
 COPY --from=kernel-headers /include/linux /include/linux
 
 WORKDIR /mnt


### PR DESCRIPTION
### Summary
Dockerfile definition change to update the file permission to be `644` rather than `600` for the `linux.bin`. It fixes a reported error when using the latest CLI (`alpha.32`) and running `cartesi build` on an `Ubuntu 24.04.4 LTS`  environment. More details [here](#454)

The permission changed from sdk `alpha.35` forward.


closes #454 