### PR TITLE
feat: update rollups explorer service

### DIFF
--- a/.changeset/rude-mirrors-travel.md
+++ b/.changeset/rude-mirrors-travel.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Bump cartesi SDK to version 0.12.0-alpha.39. It includes the new rollups-node 2.0.0-alpha.11

--- a/.changeset/young-foxes-try.md
+++ b/.changeset/young-foxes-try.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Update explorer compose definitions to integrate with new rollups-explorer service.

--- a/apps/cli/src/compose/explorer.ts
+++ b/apps/cli/src/compose/explorer.ts
@@ -1,101 +1,9 @@
-import { anvil } from "viem/chains";
 import type { ComposeFile, Config, Service } from "../types/compose.js";
 import { DEFAULT_HEALTHCHECK } from "./common.js";
 
 type ServiceOptions = {
-    databaseHost?: string;
-    databasePassword: string;
-    databasePort?: number;
-    apiTag?: string;
     imageTag?: string;
     port?: number;
-};
-
-// Explorer API service
-export const apiService = (options: ServiceOptions): Service => {
-    const imageTag = options.apiTag ?? "latest";
-    const databasePassword = options.databasePassword;
-    const databaseHost = options.databaseHost ?? "database";
-    const databasePort = options.databasePort ?? 5432;
-
-    return {
-        image: `cartesi/rollups-explorer-api:${imageTag}`,
-        environment: {
-            DB_PORT: databasePort.toString(),
-            DB_HOST: databaseHost,
-            DB_PASS: databasePassword,
-            DB_NAME: "explorer",
-            GQL_PORT: 4350,
-        },
-        expose: ["4350"],
-        command: ["sqd", "serve:prod"],
-        healthcheck: {
-            ...DEFAULT_HEALTHCHECK,
-            test: [
-                "CMD",
-                "wget",
-                "--spider",
-                "-q",
-                "http://127.0.0.1:4350/graphql?query=%7B__typename%7D",
-            ],
-        },
-        depends_on: {
-            database: { condition: "service_healthy" },
-        },
-    };
-};
-
-// Explorer API Proxy configuration
-export const explorerApiProxyConfig = (): Config => {
-    return {
-        name: "explorer-api-proxy",
-        content: `http:
-    routers:
-        explorer-api:
-            rule: "PathPrefix(\`/explorer-api\`)"
-            middlewares:
-                - "remove-explorer-api-prefix"
-            service: explorer_api
-    middlewares:
-        remove-explorer-api-prefix:
-            replacePathRegex:
-                regex: "^/explorer-api/(.*)"
-                replacement: "/$1"
-    services:
-        explorer_api:
-            loadBalancer:
-                servers:
-                    - url: "http://explorer_api:4350"
-`,
-    };
-};
-
-// Squid Processor service
-export const squidProcessorService = (options: ServiceOptions): Service => {
-    const imageTag = options.apiTag ?? "latest";
-    const databasePassword = options.databasePassword;
-    const databaseHost = options.databaseHost ?? "database";
-    const databasePort = options.databasePort ?? 5432;
-    const chain = anvil;
-    const environment: Record<string, string | number> = {
-        DB_HOST: databaseHost,
-        DB_NAME: "explorer",
-        DB_PASS: databasePassword,
-        DB_PORT: databasePort.toString(),
-        CHAIN_IDS: chain.id.toString(),
-    };
-    environment[`RPC_URL_${chain.id}`] = `http://anvil:8545`;
-    environment[`BLOCK_CONFIRMATIONS_${chain.id}`] = 0;
-    environment[`GENESIS_BLOCK_${chain.id}`] = 1;
-
-    return {
-        image: `cartesi/rollups-explorer-api:${imageTag}`,
-        environment,
-        command: ["sqd", "process:prod"],
-        depends_on: {
-            database: { condition: "service_healthy" },
-        },
-    };
 };
 
 // Explorer service
@@ -104,18 +12,29 @@ export const explorerService = (options: ServiceOptions): Service => {
     const port = options.port ?? 6571;
 
     const nodeRpcUrl = `http://127.0.0.1:${port}/anvil`;
-    const explorerApiUrl = `http://127.0.0.1:${port}/explorer-api/graphql`;
+    const cartesiNodeRpcUrl = `http://127.0.0.1:${port}/rpc`;
 
     return {
         image: `cartesi/rollups-explorer:${imageTag}`,
         environment: {
-            CHAIN_ID: 31337,
-            EXPLORER_API_URL: explorerApiUrl,
             NODE_RPC_URL: nodeRpcUrl,
+            CARTESI_NODE_RPC_URL: cartesiNodeRpcUrl,
         },
         expose: ["3000"],
+        healthcheck: {
+            ...DEFAULT_HEALTHCHECK,
+            test: [
+                "CMD",
+                "wget",
+                "--spider",
+                "-q",
+                `http://127.0.0.1:3000/explorer/api/healthz`,
+            ],
+        },
+
         depends_on: {
-            database: { condition: "service_healthy" },
+            anvil: { condition: "service_healthy" },
+            rollups_node: { condition: "service_healthy" },
         },
     };
 };
@@ -139,22 +58,15 @@ export const explorerProxyConfig = (): Config => {
 
 export default (options: ServiceOptions): ComposeFile => ({
     configs: {
-        explorer_api_proxy: explorerApiProxyConfig(),
         explorer_proxy: explorerProxyConfig(),
     },
     services: {
-        explorer_api: apiService(options),
         explorer: explorerService(options),
-        squid_processor: squidProcessorService(options),
         proxy: {
             configs: [
                 {
                     source: "explorer_proxy",
                     target: "/etc/traefik/conf.d/explorer.yaml",
-                },
-                {
-                    source: "explorer_api_proxy",
-                    target: "/etc/traefik/conf.d/explorer-api.yaml",
                 },
             ],
         },

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.38";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.39";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 

--- a/apps/cli/src/exec/rollups.ts
+++ b/apps/cli/src/exec/rollups.ts
@@ -182,7 +182,7 @@ const availableServices: Service[] = [
     },
     {
         name: "explorer",
-        healthySemaphore: "explorer_api",
+        healthySemaphore: "explorer",
         healthyTitle: (port) =>
             `${chalk.cyan("explorer")} service ready at ${chalk.cyan(`${host}:${port}/explorer`)}`,
         waitTitle: `${chalk.cyan("explorer")} service starting...`,
@@ -302,9 +302,7 @@ export const startEnvironment = async (options: {
     if (services.includes("explorer")) {
         files.push(
             explorer({
-                imageTag: "1.4.0",
-                apiTag: "1.1.0",
-                databasePassword,
+                imageTag: "2.0.0-alpha.2",
                 port,
             }),
         );


### PR DESCRIPTION
# Summary
Update the configuration to use the new rollups-explorer service.

Changes:
* Remove dependencies on the database.
* Remove dependencies on squid indexer.
* Remove dependencies on GraphQL API. 
* Set up Docker depends-on definition, i.e. [node, anvil] .
* Set up the Docker health-check definition against a `/healthz` endpoint.
* Update the healthy-semaphore definitions for the new explorer.


## Dependencies

- [x] Depends on PR https://github.com/cartesi/rollups-explorer/pull/444
- [x] Release on rollups-explorer `2.0.0-alpha.2`: [2.0.0-alpha.2 prerelease](https://github.com/cartesi/rollups-explorer/releases/tag/v2.0.0-alpha.2)
- [x] Release cartesi/sdk@0.12.0-alpha.39: [docker hub link](https://hub.docker.com/layers/cartesi/sdk/0.12.0-alpha.39/images/sha256-afb3b0daa0c78c3849aab36a215373af7f47341a6df3096c088a1cf979adf3cb)

