### PR TITLE
chore(cli): Bump CLI default SDK to alpha.38.

### DIFF
--- a/.changeset/fresh-swans-attend.md
+++ b/.changeset/fresh-swans-attend.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Bump CLI default SDK version from alpha.37 to alpha.38.

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -73,7 +73,7 @@ export class InvalidStringArrayError extends Error {
  */
 const DEFAULT_FORMAT = "ext2";
 const DEFAULT_RAM = "128Mi";
-export const DEFAULT_SDK_VERSION = "0.12.0-alpha.37";
+export const DEFAULT_SDK_VERSION = "0.12.0-alpha.38";
 export const DEFAULT_SDK_IMAGE = "cartesi/sdk";
 export const PREFERRED_PORT = 6751;
 


### PR DESCRIPTION
# Summary

The code change mainly upgrades the default SDK version to the latest (alpha. 38). It fixes a file permission change introduced on `sdk@2.0.0-alpha.35`, making the access to `linux.bin` more strict than usual, which causes a `permission denied` error when running the CLI command `cartesi build`.