### PR TITLE
ci: bump docker actions

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -71,14 +71,14 @@ jobs:
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Login to DockerHub
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+              uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
               with:
                   bake-target: docker-metadata-${{ matrix.target }}
                   images: |

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -84,11 +84,10 @@ jobs:
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
+              uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}
               with:
-                  workdir: packages/sdk
-                  source: .
+                  source: ./packages/sdk
                   targets: |
                       rollups-database
                       rollups-runtime

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -68,7 +68,7 @@ jobs:
                   path: packages/sdk/
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
# Summary
Group change targeting GH actions.


After merging this PR will be able to close the following, which is targeting `main` rather than `prerelease/v2-alpha`

* #440 
* #441 
* #442 
* #443 
