### PR TITLE
chore: sdk machine emulator bump

### DIFF
--- a/.changeset/five-dots-end.md
+++ b/.changeset/five-dots-end.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Bump cartesi-machine-emulator to 0.20.0. Also bump cartesi-base-image and postgres-base-image to use debian:trixie on specific date and hash.

--- a/.changeset/hot-eagles-return.md
+++ b/.changeset/hot-eagles-return.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Bump rollups-node to v2.0.0-alpha.12 and update the Dockerfile shasum checks.

--- a/.changeset/plenty-chicken-know.md
+++ b/.changeset/plenty-chicken-know.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Add new apt-get dependency libgomp1 and update the shasum check for the emulator artefacts based on arch.

--- a/.changeset/red-flowers-smash.md
+++ b/.changeset/red-flowers-smash.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Bump cartesi devnet version to 2.0.0-alpha.14.

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -185,8 +185,8 @@ RUN <<EOF
 curl -fsSL https://github.com/cartesi/rollups-node/releases/download/v${CARTESI_ROLLUPS_NODE_VERSION}/cartesi-rollups-node-v${CARTESI_ROLLUPS_NODE_VERSION}_${TARGETARCH}.deb \
     -o /tmp/cartesi-rollups-node.deb
 case "${TARGETARCH}" in
-    amd64) echo "72a7db2aabbf0e8d58849c9546f7c180f68c9d0550606d536d42882603550fb4 /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
-    arm64) echo "b50b445355dda23ee06f08e7d28ed8452025e59934310c7a8115531af6eeae0c /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
+    amd64) echo "b2db03fcab1453238346fe6638b50693a405659fd73fe3ddca5be8d4e950528a /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
+    arm64) echo "e080a25f19f04b3d2164354c49989dcd72c02af6866623a70816eb08f0d75490 /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
 apt-get install -y --no-install-recommends /tmp/cartesi-rollups-node.deb

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -148,6 +148,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 apt-get install -y --no-install-recommends \
     libslirp0 \
+    libgomp1 \
     lua5.4
 rm -rf /var/lib/apt/lists/*
 EOF
@@ -170,8 +171,8 @@ RUN <<EOF
 curl -fsSL https://github.com/cartesi/machine-emulator/releases/download/v${CARTESI_MACHINE_EMULATOR_VERSION}/machine-emulator_${TARGETARCH}.deb \
     -o /tmp/machine-emulator.deb
 case "${TARGETARCH}" in
-    amd64) echo "adae6b030a8990e316997aad53d175192bfeaa84ad12ee19491366377073572b  /tmp/machine-emulator.deb" | sha256sum --check ;;
-    arm64) echo "15ebb64d8cd3296564d2297dd809d1d72c13a938976bb4ecc5e5c82e71bb8069  /tmp/machine-emulator.deb" | sha256sum --check ;;
+    amd64) echo "46b2f37b889091df3b89a8909467935f8dd4a1426eeb0491b6a346a12f0c341c  /tmp/machine-emulator.deb" | sha256sum --check ;;
+    arm64) echo "27ea10571335ad174b75388e7de54a3d3434bd607554d8c0bdf6abca47ceae0d  /tmp/machine-emulator.deb" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
 apt-get install -y --no-install-recommends /tmp/machine-emulator.deb

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -7,12 +7,12 @@ target "default" {
   inherits = ["docker-platforms"]
   args = {
     ALTO_VERSION                      = "1.2.7"
-    ALTO_PACKAGE_VERSION              = "0.0.20"
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:bookworm-20260223-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421"
+    ALTO_PACKAGE_VERSION              = "0.0.20"    
+    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20260518@sha256:4ae67669760b807c19f23902a3fd7c121a6a70cf2ae709035674b23e712e4d62"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.11"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
-    CARTESI_MACHINE_EMULATOR_VERSION  = "0.19.0"
+    CARTESI_MACHINE_EMULATOR_VERSION  = "0.20.0"
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.11"
@@ -20,7 +20,7 @@ target "default" {
     NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "24.14.0"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-bookworm@sha256:ed736a0232f124704e442614fa13a042c4471b76af79dc74ddcf72023e351ed2"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:3faba5d113bdbdfda79ed7f0d68ddae736d17473e8888e250f2471c651694f3f"
     SQUASHFS_TOOLS_VERSION            = "bad1d213ab6df587d6fa0ef7286180fbf7b86167" # 4.7.4
     SU_EXEC_VERSION                   = "0.3"
     TELEGRAF_VERSION                  = "1.38.0"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -15,7 +15,7 @@ target "default" {
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.20.0"
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
-    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.11"
+    CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.12"
     FOUNDRY_VERSION                   = "1.4.3"
     NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "24.14.0"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -7,8 +7,8 @@ target "default" {
   inherits = ["docker-platforms"]
   args = {
     ALTO_VERSION                      = "1.2.7"
-    ALTO_PACKAGE_VERSION              = "0.0.20"    
-    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20260518@sha256:4ae67669760b807c19f23902a3fd7c121a6a70cf2ae709035674b23e712e4d62"
+    ALTO_PACKAGE_VERSION              = "0.0.20"
+    CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20260610@sha256:fe7312b5f05bf5f43fad76bcd8945642e4e47a68aefd1b73f447615899d0fac1"
     CARTESI_DEVNET_VERSION            = "2.0.0-alpha.14"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
@@ -20,7 +20,7 @@ target "default" {
     NITRO_VERSION                     = "8c376d4a5baa7f32999620f9fe3eb51ca8e0dcbc" # v0.5
     NODE_VERSION                      = "24.14.0"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3
-    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:3faba5d113bdbdfda79ed7f0d68ddae736d17473e8888e250f2471c651694f3f"
+    POSTGRES_BASE_IMAGE               = "docker.io/library/postgres:17-trixie@sha256:2203e6282d9e7de7c24d7da234e2a744fb325df366a3fd8ed940e8abbee39527"
     SQUASHFS_TOOLS_VERSION            = "bad1d213ab6df587d6fa0ef7286180fbf7b86167" # 4.7.4
     SU_EXEC_VERSION                   = "0.3"
     TELEGRAF_VERSION                  = "1.38.0"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -9,7 +9,7 @@ target "default" {
     ALTO_VERSION                      = "1.2.7"
     ALTO_PACKAGE_VERSION              = "0.0.20"    
     CARTESI_BASE_IMAGE                = "docker.io/library/debian:trixie-20260518@sha256:4ae67669760b807c19f23902a3fd7c121a6a70cf2ae709035674b23e712e4d62"
-    CARTESI_DEVNET_VERSION            = "2.0.0-alpha.11"
+    CARTESI_DEVNET_VERSION            = "2.0.0-alpha.14"
     CARTESI_IMAGE_KERNEL_VERSION      = "0.20.0"
     CARTESI_LINUX_KERNEL_VERSION      = "6.5.13-ctsi-1-v0.20.0"
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.20.0"


### PR DESCRIPTION
# Summary
SDK changes to accommodate the cartesi machine emulator bump. 

To see and build an SDK Docker image, I am using a rollups-node artefact from [build next/2.0#2b0eac](https://github.com/cartesi/rollups-node/actions/runs/25513516564) for local checks. 

Addition:
- A new apt-get dependency needed to be installed, called `libgomp1`, or the step for the runtime was failing and highlighting the need for such a lib, but could not be installed.

Upgrades:
- CARTESI_BASE_IMAGE bumped to use `debian:trixie-trixie-20260610@sha256:fe7312b5f05bf5f43fad76bcd8945642e4e47a68aefd1b73f447615899d0fac1`
- CARTESI_MACHINE_EMULATOR_VERSION bumped to `0.20.0`
- POSTGRES_BASE_IMAGE bumped to `postgres:17-trixie@sha256:2203e6282d9e7de7c24d7da234e2a744fb325df366a3fd8ed940e8abbee39527`
- CARTESI_ROLLUPS_NODE_VERSION to `2.0.0-alpha.12`


### Check steps 
Requires: Docker, `jq`

After building the `sdk` image, you can run the following to check specific contents.

Check `devnet-alpha.14`:  
```shell
docker run -ti --rm cartesi/sdk:devel cat  /usr/share/cartesi/deployments/anvil.json | jq '.contracts["TestUsdWithdrawalOutputBuilder"]'
```

Check cartesi-machine `0.20.0`
```shell
docker run -ti --rm cartesi/sdk:devel cartesi-machine --version
```

Check rollups-node `alpha.12`:

```shell
docker run -ti --rm cartesi/sdk:devel cartesi-rollups-cli --version
```


