### PR TITLE
refactor(devnet): Configure sequential tasks and exit on error

### DIFF
--- a/.changeset/sweet-items-film.md
+++ b/.changeset/sweet-items-film.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+Download artifacts dependencies sequentially to avoid race-condition errors when creating directories and files, which can result in EEXIST followed by ENOENT errors. Also, explicitly configure the task runner to exit on error, so it doesn't publish a package with missing required information.

--- a/packages/devnet/build.ts
+++ b/packages/devnet/build.ts
@@ -189,7 +189,7 @@ const build = async () => {
             {
                 title: "Download dependencies",
                 task: async (_, task) =>
-                    task.newListr(dependencies, { concurrent: true }),
+                    task.newListr(dependencies, { concurrent: false }),
             },
             {
                 title: "Starting anvil...",
@@ -261,7 +261,7 @@ const build = async () => {
                 },
             },
         ],
-        { exitOnError: false },
+        { exitOnError: true },
     );
 
     await tasks.run({


### PR DESCRIPTION
## Summary
Code changes to stop publishing of now-considered-incomplete builds and also to avoid race conditions in the `dependencies` task, which downloads and extracts artefact information. After the release/publishing of version `alpha.12`, the expected **testnet** and **mainnet** deployment information was missing. Through careful checking in the [release action:8:43](https://github.com/cartesi/cli/actions/runs/26459632176/job/77903467711#step:8:43),  an `EEXIST` followed by an `ENOENT` error was logged.  

In more detail, local replication is not 100% guaranteed due to timing, but it occurs not only in the temporary folder `build/` but also a few times in the `out/` folder, as the build process flattens content and puts it together for subsequent tasks to consume. 

As a result, the download and extraction tasks now run sequentially, and the Task runner is explicitly instructed to exit on error.