### PR TITLE
feat(sdk): add cartesi sequencer:v0.1.0-alpha.7

### DIFF
--- a/.changeset/chubby-ideas-drive.md
+++ b/.changeset/chubby-ideas-drive.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+add cartesi sequencer:v0.1.0-alpha.7

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -137,6 +137,23 @@ telegraf --version
 EOF
 
 ################################################################################
+# install cartesi-sequencer
+FROM base AS cartesi-sequencer
+ARG CARTESI_SEQUENCER_VERSION
+ARG TARGETARCH
+RUN <<EOF
+curl -fsSL https://github.com/cartesi/sequencer/releases/download/v${CARTESI_SEQUENCER_VERSION}/sequencer-v${CARTESI_SEQUENCER_VERSION}-linux-${TARGETARCH}.tar.gz \
+    -o /tmp/sequencer.tar.gz
+case "${TARGETARCH}" in
+    amd64) echo "4bf51df82406244769bfa2c9b75021099fe39f399cc2092306b4d6082e3a3d3d /tmp/sequencer.tar.gz" | sha256sum --check ;;
+    arm64) echo "a972fc723d8c8824170831ee0d5ee7afd51758da5a2e4973715452565afc319c /tmp/sequencer.tar.gz" | sha256sum --check ;;
+    *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
+esac
+tar -xvzf /tmp/sequencer.tar.gz -C /usr/local/bin --strip-components=1 sequencer-v${CARTESI_SEQUENCER_VERSION}-linux-${TARGETARCH}/sequencer
+sequencer --version
+EOF
+
+################################################################################
 # cartesi rollups-runtime target
 FROM base AS rollups-runtime
 ARG CARTESI_MACHINE_EMULATOR_VERSION
@@ -202,6 +219,7 @@ COPY --from=nitro /usr/local/src/nitro /usr/local/bin/
 COPY --from=nitro /usr/local/src/nitroctl /usr/local/bin/
 COPY --from=tini /usr/local/bin/tini /usr/local/bin/
 COPY --from=telegraf /usr/local/bin/telegraf /usr/local/bin/
+COPY --from=cartesi-sequencer /usr/local/bin/sequencer /usr/local/bin/
 COPY skel/ /
 RUN <<EOF
 mkdir -p /run/nitro

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -16,6 +16,7 @@ target "default" {
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.12"
+    CARTESI_SEQUENCER_VERSION         = "0.1.0-alpha.7"
     FOUNDRY_VERSION                   = "1.4.3"
     NITRO_VERSION                     = "c937fa4fd202074dd250086ebd92de6884968b84" # v0.8.1
     NODE_VERSION                      = "24.14.0"


### PR DESCRIPTION
The sequencer binary is necessary in the SDK image if the developer want's to use the sequencer to send inputs instead of relying only on the InputBox.

cartesi/cli still needs to be adapted to use this service.