### PR TITLE
feat: Devnet update anvil + contracts

### DIFF
--- a/.changeset/real-adults-slide.md
+++ b/.changeset/real-adults-slide.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/devnet": patch
+---
+
+Bump devnet anvil version from 1.4.3 to 1.5.1

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -26,7 +26,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # 1.6.0
               with:
-                  version: v1.4.3
+                  version: v1.5.1
 
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -26,7 +26,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # 1.6.0
               with:
-                  version: v1.4.3
+                  version: v1.5.1
 
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # 1.6.0
               with:
-                  version: v1.4.3
+                  version: v1.5.1
 
             - name: Install Dependencies
               run: bun install --frozen-lockfile

--- a/packages/devnet/build.ts
+++ b/packages/devnet/build.ts
@@ -16,7 +16,7 @@ import {
 import * as anvil from "./anvil";
 import { downloadAndExtract } from "./download";
 
-const ANVIL_VERSION = "1.4.3";
+const ANVIL_VERSION = "1.5.1";
 const ROLLUPS_VERSION = "3.0.0-alpha.6";
 const PRT_VERSION = "3.0.0-alpha.3";
 


### PR DESCRIPTION
# Summary
Changes to align with downstream stack changes and contracts releases; e.g. Foundry bump to use 1.5.1 and also update the contracts version.

Details:
*  #502 