### PR TITLE
chore(paymaster): Bump foundry install to v1.5.1 for paymaster GA.

### DIFF
--- a/.github/workflows/paymaster.yaml
+++ b/.github/workflows/paymaster.yaml
@@ -26,7 +26,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # 1.6.0
               with:
-                  version: v1.4.3
+                  version: v1.5.1
 
             - name: Install dependencies
               run: bun install --frozen-lockfile


### PR DESCRIPTION
# Summary
Change to bump Foundry installation from **v1.4.3 to v1.5.1** to match the upcoming stack update. It does not require a release, as there are no changes to the package itself, but only an upgrade in the GitHub action related to it. 

Details are related to: 
* #502 

PS: I will currently target the merge to the draft PR related to the devnet changes. In case there are other required changes based on possible suggestions leading to a changeset entry, I may switch to the `prerelease/v2-alpha` branch instead. 