### PR TITLE
feat(cli): Add support to NVRAM

### DIFF
--- a/.changeset/clear-falcons-wonder.md
+++ b/.changeset/clear-falcons-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Fix the cartesi-machine version check ignoring its `forceDocker` option, which made it report the version of the host binary instead of the one inside the SDK image.

--- a/.changeset/free-facts-stare.md
+++ b/.changeset/free-facts-stare.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+`build` and `shell` now check the cartesi-machine version before booting and stop with an explicit message when it is unsupported, instead of surfacing the emulator's `unrecognized option` traceback.

--- a/.changeset/fresh-pumas-clap.md
+++ b/.changeset/fresh-pumas-clap.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/sdk": patch
+---
+
+Bump anvil and foundry to 1.5.1, and the cartesi-rollups-prt release providing the anvil state to 3.0.0-alpha.4.

--- a/.changeset/tired-lights-worry.md
+++ b/.changeset/tired-lights-worry.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Add support for `nvrams` in `cartesi.toml`. An nvram is a raw range of bytes the guest reaches through a `/dev/uio*` device, with no filesystem and no mount point, so writes are visible to the emulator without a page cache in between. Declare one with `[nvrams.<label>]` and either `size`, for a range filled with zeros, or `filename`, pointing at an existing raw image whose size defines the range. Add `shared` so guest writes are persisted to the image, and `user` so the unprivileged entrypoint user can write to it. Up to 8 nvrams are supported, their labels cannot collide with drive labels, and sizes must be a multiple of 4Ki.

--- a/.changeset/violet-flies-rest.md
+++ b/.changeset/violet-flies-rest.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Require cartesi-machine 0.21.0. The `nvrams` configuration depends on its `--nvram` option, so the default SDK image has to be bumped to one shipping 0.21.0, and a host install of previous version will no longer work.

--- a/.changeset/wild-camels-sink.md
+++ b/.changeset/wild-camels-sink.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+`doctor` now reports the cartesi-machine version and fails when it does not satisfy the version required by the CLI.

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -4,6 +4,7 @@ on:
         paths:
             - ".github/workflows/cli.yaml"
             - "apps/cli/**"
+            - "packages/sdk/**"
             - "packages/tsconfig/**"
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -18,6 +19,9 @@ jobs:
         env:
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+            # TEMPORARY: run the integration tests against the SDK image sdk.yaml
+            # builds for this PR, instead of the released cartesi/sdk version.
+            CARTESI_TEST_SDK: ghcr.io/cartesi/sdk:pr-${{ github.event.number }}
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,6 +44,14 @@ jobs:
 
             - name: Build
               run: bun run build --filter @cartesi/cli
+
+            # TEMPORARY: needed to pull the PR-tagged SDK image referenced by CARTESI_TEST_SDK.
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test
               run: bun test apps/cli/

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -83,6 +83,10 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Fetch Temporary rollups-node debs
+              run: ./temp/fetch.sh
+              working-directory: packages/sdk
+
             - name: Build and push
               uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
               if: ${{ !startsWith(github.ref, 'refs/tags/sdk@') }}

--- a/apps/cli/src/builder/index.ts
+++ b/apps/cli/src/builder/index.ts
@@ -2,4 +2,5 @@ export { build as buildDirectory } from "./directory.js";
 export { build as buildDocker } from "./docker.js";
 export { build as buildEmpty } from "./empty.js";
 export { build as buildNone } from "./none.js";
+export { build as buildNvram } from "./nvram.js";
 export { build as buildTar } from "./tar.js";

--- a/apps/cli/src/builder/nvram.ts
+++ b/apps/cli/src/builder/nvram.ts
@@ -1,0 +1,47 @@
+import fs from "fs-extra";
+import path from "node:path";
+import {
+    MissingNvramSourceError,
+    NVRAM_ALIGNMENT,
+    type NvramConfig,
+    nvramHasImage,
+    nvramImageFilename,
+} from "../config.js";
+
+export const build = async (
+    label: string,
+    nvram: NvramConfig,
+    destination: string,
+): Promise<void> => {
+    // a pristine nvram needs no image, cartesi-machine fills its range with zeros
+    if (!nvramHasImage(nvram)) {
+        return;
+    }
+
+    const target = path.join(destination, nvramImageFilename(label));
+    const source = nvram.filename;
+
+    if (source === undefined) {
+        // shared with no image of its own, start it filled with zeros
+        if (nvram.size === undefined) {
+            throw new MissingNvramSourceError(label);
+        }
+        await fs.writeFile(target, Buffer.alloc(nvram.size));
+        return;
+    }
+
+    const { size } = await fs.stat(source);
+    if (nvram.size !== undefined && nvram.size !== size) {
+        throw new Error(
+            `Size ${nvram.size} of nvram '${label}' does not match the ${size} bytes of ${source}`,
+        );
+    }
+    if (size % NVRAM_ALIGNMENT !== 0) {
+        throw new Error(
+            `Image ${source} of nvram '${label}' has ${size} bytes, which is not a multiple of ${NVRAM_ALIGNMENT}`,
+        );
+    }
+
+    // copy it into the destination, so it is reachable when running inside the sdk image
+    await fs.copyFile(source, target);
+};

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -10,9 +10,10 @@ import {
     buildDocker,
     buildEmpty,
     buildNone,
+    buildNvram,
     buildTar,
 } from "../builder/index.js";
-import type { Config, DriveConfig, ImageInfo } from "../config.js";
+import type { Config, DriveConfig, ImageInfo, NvramConfig } from "../config.js";
 import { bootMachine } from "../machine.js";
 
 // context for Listr build tasks
@@ -79,6 +80,17 @@ const buildDriveTask = (
     },
 });
 
+const buildNvramTask = (
+    label: string,
+    nvram: NvramConfig,
+): ListrTask<BuildContext> => ({
+    title: `Building nvram ${chalk.cyan(label)}`,
+    task: async (ctx, task) => {
+        await buildNvram(label, nvram, ctx.destination);
+        task.title = `Build nvram ${chalk.cyan(label)}`;
+    },
+});
+
 export const createBuildCommand = () => {
     return new Command("build")
         .description(
@@ -129,23 +141,45 @@ export const createBuildCommand = () => {
                 ([name, drive]) => buildDriveTask(name, drive),
             );
 
-            const builds = new Listr(
-                [
-                    {
-                        title: "Build drives",
-                        task: async (_ctx, task) => {
-                            return task.newListr(driveTasks, {
-                                concurrent: true,
-                                rendererOptions: {
-                                    collapseSubtasks: false,
-                                },
-                                ctx,
-                            });
-                        },
-                    },
-                ],
-                { ctx, renderer: verbose ? "verbose" : "default" },
+            // tasks to build the images backing nvrams, pristine ones need none
+            const nvramTasks = Object.entries(config.nvrams).map(
+                ([label, nvram]) => buildNvramTask(label, nvram),
             );
+
+            const groups: ListrTask<BuildContext>[] = [
+                {
+                    title: "Build drives",
+                    task: async (_ctx, task) => {
+                        return task.newListr(driveTasks, {
+                            concurrent: true,
+                            rendererOptions: {
+                                collapseSubtasks: false,
+                            },
+                            ctx,
+                        });
+                    },
+                },
+            ];
+
+            if (nvramTasks.length > 0) {
+                groups.push({
+                    title: "Build nvrams",
+                    task: async (_ctx, task) => {
+                        return task.newListr(nvramTasks, {
+                            concurrent: true,
+                            rendererOptions: {
+                                collapseSubtasks: false,
+                            },
+                            ctx,
+                        });
+                    },
+                });
+            }
+
+            const builds = new Listr(groups, {
+                ctx,
+                renderer: verbose ? "verbose" : "default",
+            });
             const result = await builds.run();
 
             // if only build drives, quit here

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -3,6 +3,8 @@ import chalk from "chalk";
 import { execa } from "execa";
 import ora, { type Ora } from "ora";
 import semver from "semver";
+import { DEFAULT_SDK_IMAGE, DEFAULT_SDK_VERSION } from "../config.js";
+import { cartesiMachine } from "../exec/index.js";
 
 const MINIMUM_DOCKER_VERSION = "25.0.0"; // Replace with our minimum required Docker version
 const MINIMUM_DOCKER_COMPOSE_VERSION = "2.24.0"; // Replace with our minimum required Docker Compose version
@@ -119,6 +121,30 @@ const checkBuildx = async (progress: Ora): Promise<true | never> => {
     return true;
 };
 
+const checkCartesiMachine = async (progress: Ora): Promise<true | never> => {
+    progress.start("Checking Cartesi Machine version...");
+
+    // doctor does not read cartesi.toml, so check against the default sdk image. the host binary
+    // still takes precedence, which is the install most likely to be out of date
+    const v = await cartesiMachine.version({
+        image: `${DEFAULT_SDK_IMAGE}:${DEFAULT_SDK_VERSION}`,
+    });
+
+    if (v === null) {
+        throw new Error(
+            "Could not determine the Cartesi Machine version. Check that Docker is running.",
+        );
+    }
+    if (!semver.satisfies(v.format(), cartesiMachine.requiredVersion)) {
+        throw new Error(
+            `Unsupported Cartesi Machine version. Required version is ${cartesiMachine.requiredVersion.raw}. Installed version is ${v.format()}.`,
+        );
+    }
+    progress.succeed(`Cartesi Machine ${chalk.cyan(v.format())}`);
+
+    return true;
+};
+
 export const createDoctorCommand = () => {
     return new Command("doctor").action(async () => {
         const progress = ora();
@@ -126,6 +152,7 @@ export const createDoctorCommand = () => {
             await checkDocker(progress);
             await checkCompose(progress);
             await checkBuildx(progress);
+            await checkCartesiMachine(progress);
             progress.succeed("Your system is ready.");
         } catch (e: unknown) {
             progress.fail((e as Error).message);

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -3,6 +3,7 @@ import { ExecaError } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 import { getApplicationConfig, getContextPath } from "../base.js";
+import { nvramHasImage, nvramImageFilename } from "../config.js";
 import { bootMachine } from "../machine.js";
 
 export const createShellCommand = () => {
@@ -30,6 +31,17 @@ export const createShellCommand = () => {
                 const pathname = getContextPath(filename);
                 if (!fs.existsSync(pathname)) {
                     throw new Error(`drive '${name}' not built, run 'build'`);
+                }
+            }
+
+            // check if all nvrams backed by an image are built, pristine ones have none
+            for (const [label, nvram] of Object.entries(config.nvrams)) {
+                if (!nvramHasImage(nvram)) {
+                    continue;
+                }
+                const pathname = getContextPath(nvramImageFilename(label));
+                if (!fs.existsSync(pathname)) {
+                    throw new Error(`nvram '${label}' not built, run 'build'`);
                 }
             }
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -3,7 +3,7 @@ import { extname } from "node:path";
 import { parse as parseToml, type TomlPrimitive } from "smol-toml";
 import { getAddress, isAddress, isHex, type Address } from "viem";
 
-const NVRAM_ALIGNMENT = 4096; // cartesi-machine requires length % 4Ki == 0
+export const NVRAM_ALIGNMENT = 4096; // cartesi-machine requires length % 4Ki == 0
 const MAX_NVRAMS = 8; // guest exposes nvrams as /dev/uio0 to /dev/uio7
 
 /**

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -3,6 +3,9 @@ import { extname } from "node:path";
 import { parse as parseToml, type TomlPrimitive } from "smol-toml";
 import { getAddress, isAddress, isHex, type Address } from "viem";
 
+const NVRAM_ALIGNMENT = 4096; // cartesi-machine requires length % 4Ki == 0
+const MAX_NVRAMS = 8; // guest exposes nvrams as /dev/uio0 to /dev/uio7
+
 /**
  * Typed Errors
  */
@@ -85,6 +88,36 @@ export class InvalidEnvError extends Error {
     }
 }
 
+export class MissingNvramSourceError extends Error {
+    constructor(label: string) {
+        super(`Nvram '${label}' must define either 'size' or 'filename'`);
+        this.name = "MissingNvramSourceError";
+    }
+}
+
+export class InvalidNvramSizeError extends Error {
+    constructor(label: string, size: number) {
+        super(
+            `Invalid size ${size} for nvram '${label}': must be a positive multiple of ${NVRAM_ALIGNMENT}`,
+        );
+        this.name = "InvalidNvramSizeError";
+    }
+}
+
+export class TooManyNvramsError extends Error {
+    constructor(count: number) {
+        super(`Too many nvrams: ${count}, maximum is ${MAX_NVRAMS}`);
+        this.name = "TooManyNvramsError";
+    }
+}
+
+export class DuplicateLabelError extends Error {
+    constructor(label: string) {
+        super(`Label '${label}' is used by both a drive and an nvram`);
+        this.name = "DuplicateLabelError";
+    }
+}
+
 /**
  * Configuration for drives of a Cartesi Machine. A drive may already exist or be built by a builder
  */
@@ -156,6 +189,18 @@ export type DriveConfig = (
     user?: string; // default given by cartesi-machine
 };
 
+/**
+ * Configuration for an NVRAM of a Cartesi Machine. Unlike a flash drive, an nvram is a raw
+ * range of bytes exposed to the guest as a /dev/uio* device, with no filesystem and no mount
+ * point. Either `size` or `filename` must be defined.
+ */
+export type NvramConfig = {
+    filename?: string; // path to an existing raw image with the initial contents
+    size?: number; // in bytes, a positive multiple of 4Ki
+    shared?: boolean; // default given by cartesi-machine
+    user?: string; // default given by cartesi-machine
+};
+
 export type MachineConfig = {
     assertRollingTemplate?: boolean; // default given by cartesi-machine
     bootargs: string[];
@@ -186,6 +231,7 @@ export type WithdrawalConfig = {
 export type Config = {
     drives: Record<string, DriveConfig>;
     machine: MachineConfig;
+    nvrams: Record<string, NvramConfig>;
     sdk: string;
     withdrawalConfig?: WithdrawalConfig;
 };
@@ -218,6 +264,7 @@ export const defaultMachineConfig = (): MachineConfig => ({
 export const defaultConfig = (): Config => ({
     drives: { root: defaultRootDriveConfig() },
     machine: defaultMachineConfig(),
+    nvrams: {},
     sdk: `${DEFAULT_SDK_IMAGE}:${DEFAULT_SDK_VERSION}`,
     withdrawalConfig: undefined,
 });
@@ -393,6 +440,97 @@ const parseBytes = (value: TomlPrimitive, defaultValue: number): number => {
     }
     throw new InvalidBytesValueError(value);
 };
+
+const IEC_MULTIPLIERS: Record<string, number> = {
+    "": 1,
+    b: 1,
+    k: 1024,
+    ki: 1024,
+    kb: 1024,
+    kib: 1024,
+    m: 1024 ** 2,
+    mi: 1024 ** 2,
+    mb: 1024 ** 2,
+    mib: 1024 ** 2,
+    g: 1024 ** 3,
+    gi: 1024 ** 3,
+    gb: 1024 ** 3,
+    gib: 1024 ** 3,
+};
+
+/**
+ * Parses a byte size, accepting both the IEC suffixes used by cartesi-machine ("4Ki", "1MiB")
+ * and the ones understood by the `bytes` package ("4kb", "100Mb"). Not to be confused with
+ * `parseBytes`, which delegates to `bytes.parse` and reads "4Ki" as 4 bytes.
+ */
+const parseNvramSize = (value: TomlPrimitive): number | undefined => {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value === "bigint") {
+        return Number(value);
+    }
+    if (typeof value === "number") {
+        return value;
+    }
+    if (typeof value === "string") {
+        const match = /^\s*(\d+(?:\.\d+)?)\s*([a-z]*)\s*$/i.exec(value);
+        const multiplier = match
+            ? IEC_MULTIPLIERS[match[2].toLowerCase()]
+            : undefined;
+        if (match && multiplier !== undefined) {
+            return Number(match[1]) * multiplier;
+        }
+    }
+    throw new InvalidBytesValueError(value);
+};
+
+const parseNvram = (label: string, value: TomlPrimitive): NvramConfig => {
+    const toml = isTomlTable(value) ? value : {};
+    const size = parseNvramSize(toml.size);
+    const filename = parseOptionalString(toml.filename);
+
+    if (size === undefined && filename === undefined) {
+        throw new MissingNvramSourceError(label);
+    }
+    if (size !== undefined && (size <= 0 || size % NVRAM_ALIGNMENT !== 0)) {
+        throw new InvalidNvramSizeError(label, size);
+    }
+
+    return {
+        filename,
+        size,
+        shared: parseOptionalBoolean(toml.shared),
+        user: parseOptionalString(toml.user),
+    };
+};
+
+const parseNvrams = (config: TomlPrimitive): Record<string, NvramConfig> => {
+    const entries = Object.entries((config as TomlTable) ?? {});
+    if (entries.length > MAX_NVRAMS) {
+        throw new TooManyNvramsError(entries.length);
+    }
+    return entries.reduce<Record<string, NvramConfig>>(
+        (acc, [label, nvram]) => {
+            acc[label] = parseNvram(label, nvram);
+            return acc;
+        },
+        {},
+    );
+};
+
+/**
+ * Filename, relative to the build destination directory, of the image backing an nvram.
+ */
+export const nvramImageFilename = (label: string): string => `${label}.raw`;
+
+/**
+ * Whether an nvram is backed by an image file. A pristine nvram needs no image, as
+ * cartesi-machine fills its range with zeros. A `shared` one does, as there must be a file for
+ * the guest writes to be persisted to.
+ */
+export const nvramHasImage = (nvram: NvramConfig): boolean =>
+    nvram.filename !== undefined || nvram.shared === true;
 
 const parseBuilder = (value: TomlPrimitive): Builder => {
     if (value === undefined) {
@@ -639,10 +777,21 @@ export const parse = (str: string[]): Config => {
         toml = mergeTomlTables(toml, parseToml(s));
     }
 
+    const drives = parseDrives(toml.drives);
+    const nvrams = parseNvrams(toml.nvrams);
+
+    // drives and nvrams share the DTB /aliases namespace, so labels cannot collide
+    for (const label of Object.keys(nvrams)) {
+        if (drives[label] !== undefined) {
+            throw new DuplicateLabelError(label);
+        }
+    }
+
     const config: Config = {
         withdrawalConfig: parseOptionalWithdrawalConfig(toml.withdrawal),
-        drives: parseDrives(toml.drives),
+        drives,
         machine: parseMachine(toml.machine),
+        nvrams,
         sdk: parseString(
             toml.sdk,
             `${DEFAULT_SDK_IMAGE}:${DEFAULT_SDK_VERSION}`,

--- a/apps/cli/src/exec/cartesi-machine-stored-hash.ts
+++ b/apps/cli/src/exec/cartesi-machine-stored-hash.ts
@@ -29,7 +29,7 @@ export const computeHash = async (
         );
 
         if (undefined !== stdout) {
-            const hash = `0x${stdout.toString().trim()}`;
+            const hash = stdout.toString().trim();
 
             if (isHash(hash)) {
                 return hash;

--- a/apps/cli/src/exec/cartesi-machine.ts
+++ b/apps/cli/src/exec/cartesi-machine.ts
@@ -5,7 +5,7 @@ import {
     type ExecaOptionsDockerFallback,
 } from "./util.js";
 
-export const requiredVersion = new Range("^0.20.0");
+export const requiredVersion = new Range("^0.21.0");
 
 export const boot = (
     args: readonly string[],

--- a/apps/cli/src/exec/cartesi-machine.ts
+++ b/apps/cli/src/exec/cartesi-machine.ts
@@ -1,7 +1,6 @@
 import { parse, Range, type SemVer } from "semver";
 import {
     execaDockerFallback,
-    type DockerFallbackOptions,
     type ExecaOptionsDockerFallback,
 } from "./util.js";
 
@@ -13,14 +12,14 @@ export const boot = (
 ) => execaDockerFallback("cartesi-machine", args, options);
 
 export const version = async (
-    options?: DockerFallbackOptions,
+    options?: ExecaOptionsDockerFallback,
 ): Promise<SemVer | null> => {
-    const { image } = options || {};
     try {
         const { stdout } = await execaDockerFallback(
             "cartesi-machine",
             ["--version-json"],
-            { image },
+            // cwd is interpolated into the docker volume mount, so it must be defined
+            { ...options, cwd: options?.cwd ?? process.cwd() },
         );
         if (typeof stdout === "string") {
             const output = JSON.parse(stdout);

--- a/apps/cli/src/exec/cartesi-machine.ts
+++ b/apps/cli/src/exec/cartesi-machine.ts
@@ -1,4 +1,4 @@
-import { parse, Range, type SemVer } from "semver";
+import { parse, Range, satisfies, type SemVer } from "semver";
 import {
     execaDockerFallback,
     type ExecaOptionsDockerFallback,
@@ -28,5 +28,28 @@ export const version = async (
         return null;
     } catch {
         return null;
+    }
+};
+
+export class UnsupportedVersionError extends Error {
+    constructor(found: SemVer) {
+        super(
+            `cartesi-machine ${found.format()} found, but ${requiredVersion.raw} is required`,
+        );
+        this.name = "UnsupportedVersionError";
+    }
+}
+
+/**
+ * Throws if the cartesi-machine that would be used does not satisfy `requiredVersion`. A version
+ * that cannot be determined is not an error, as `version` also returns null when the binary is
+ * missing or docker is unavailable, and booting reports those on its own.
+ */
+export const assertVersion = async (
+    options?: ExecaOptionsDockerFallback,
+): Promise<void> => {
+    const found = await version(options);
+    if (found !== null && !satisfies(found.format(), requiredVersion)) {
+        throw new UnsupportedVersionError(found);
     }
 };

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -27,12 +27,11 @@ export type BootMachineOptions = {
     store?: string;
 };
 
-export const bootMachine = (
+export const buildMachineArgs = (
     config: Config,
     info: ImageInfo | undefined,
     bootOptions: BootMachineOptions,
-    options?: ExecaOptionsDockerFallback,
-) => {
+): string[] => {
     const { machine } = config;
     const {
         assertRollingTemplate,
@@ -140,8 +139,16 @@ export const bootMachine = (
     args.push("--");
     args.push(entrypoint);
 
-    return cartesiMachine.boot(args, {
+    return args;
+};
+
+export const bootMachine = (
+    config: Config,
+    info: ImageInfo | undefined,
+    bootOptions: BootMachineOptions,
+    options?: ExecaOptionsDockerFallback,
+) =>
+    cartesiMachine.boot(buildMachineArgs(config, info, bootOptions), {
         image: config.sdk,
         ...options,
     });
-};

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -1,6 +1,13 @@
 import dotenv from "dotenv";
 import fs from "node:fs";
-import type { Config, DriveConfig, ImageInfo } from "./config.js";
+import {
+    type Config,
+    type DriveConfig,
+    type ImageInfo,
+    type NvramConfig,
+    nvramHasImage,
+    nvramImageFilename,
+} from "./config.js";
 import { cartesiMachine } from "./exec/index.js";
 import type { ExecaOptionsDockerFallback } from "./exec/util.js";
 
@@ -19,6 +26,25 @@ const flashDrive = (label: string, drive: DriveConfig): string => {
     }
     // don't specify start and length
     return `--flash-drive=${vars.join(",")}`;
+};
+
+const nvram = (label: string, config: NvramConfig): string => {
+    const { shared, size, user } = config;
+    const vars = [`label:${label}`];
+    if (size !== undefined) {
+        vars.push(`length:${size}`);
+    }
+    if (nvramHasImage(config)) {
+        vars.push(`data_filename:${nvramImageFilename(label)}`);
+    }
+    if (user) {
+        vars.push(`user:${user}`);
+    }
+    if (shared) {
+        vars.push("shared");
+    }
+    // don't specify start, let cartesi-machine place it
+    return `--nvram=${vars.join(",")}`;
 };
 
 export type BootMachineOptions = {
@@ -105,11 +131,17 @@ export const buildMachineArgs = (
         flashDrive(label, drive),
     );
 
+    // keep the order the labels were declared in, as it affects the machine layout
+    const nvrams = Object.entries(config.nvrams).map(([label, nvramConfig]) =>
+        nvram(label, nvramConfig),
+    );
+
     // command to change working directory if WORKDIR is defined
     const args = [
         ...bootargs,
         ...envs,
         ...flashDrives,
+        ...nvrams,
         `--ram-length=${ramLength}`,
     ];
     if (ramImage) {

--- a/apps/cli/src/machine.ts
+++ b/apps/cli/src/machine.ts
@@ -174,13 +174,19 @@ export const buildMachineArgs = (
     return args;
 };
 
-export const bootMachine = (
+export const bootMachine = async (
     config: Config,
     info: ImageInfo | undefined,
     bootOptions: BootMachineOptions,
     options?: ExecaOptionsDockerFallback,
-) =>
-    cartesiMachine.boot(buildMachineArgs(config, info, bootOptions), {
+) => {
+    // build the args first, so a configuration error is reported without spawning anything
+    const args = buildMachineArgs(config, info, bootOptions);
+
+    await cartesiMachine.assertVersion({ image: config.sdk });
+
+    return cartesiMachine.boot(args, {
         image: config.sdk,
         ...options,
     });
+};

--- a/apps/cli/tests/integration/builder/nvram.test.ts
+++ b/apps/cli/tests/integration/builder/nvram.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "fs-extra";
+import path from "node:path";
+import { build } from "../../../src/builder/nvram.js";
+import type { NvramConfig } from "../../../src/config.js";
+import { cleanupTempDir, createTempDir } from "./tmpdirTest.js";
+
+describe("when building an nvram", () => {
+    let destination: string;
+    let source: string;
+
+    beforeEach(async () => {
+        destination = await createTempDir();
+        source = await createTempDir();
+    });
+
+    afterEach(async () => {
+        await cleanupTempDir(destination);
+        await cleanupTempDir(source);
+    });
+
+    // writes a raw image of the given size in the source directory
+    const writeImage = async (name: string, size: number) => {
+        const filename = path.join(source, name);
+        await fs.writeFile(filename, Buffer.alloc(size, 1));
+        return filename;
+    };
+
+    it("should not build an image for a pristine nvram", async () => {
+        const nvram: NvramConfig = { size: 4096 };
+        await build("input", nvram, destination);
+        expect(fs.existsSync(path.join(destination, "input.raw"))).toBeFalsy();
+    });
+
+    it("should build a zero filled image for a shared nvram", async () => {
+        const nvram: NvramConfig = { size: 8192, shared: true };
+        await build("output", nvram, destination);
+
+        const filename = path.join(destination, "output.raw");
+        const stat = await fs.stat(filename);
+        expect(stat.isFile()).toBeTruthy();
+        expect(stat.size).toEqual(8192);
+        expect(await fs.readFile(filename)).toEqual(Buffer.alloc(8192));
+    });
+
+    it("should copy an existing image", async () => {
+        const filename = await writeImage("seed.raw", 4096);
+        await build("seed", { filename }, destination);
+
+        const copy = path.join(destination, "seed.raw");
+        expect(await fs.readFile(copy)).toEqual(await fs.readFile(filename));
+    });
+
+    it("should fail for a missing image", async () => {
+        const filename = path.join(source, "missing.raw");
+        await expect(build("seed", { filename }, destination)).rejects.toThrow(
+            "no such file or directory",
+        );
+    });
+
+    it("should fail when the size does not match the image", async () => {
+        const filename = await writeImage("seed.raw", 4096);
+        await expect(
+            build("seed", { filename, size: 8192 }, destination),
+        ).rejects.toThrow(
+            `Size 8192 of nvram 'seed' does not match the 4096 bytes of ${filename}`,
+        );
+    });
+
+    it("should fail when the image size is not a multiple of 4096", async () => {
+        const filename = await writeImage("seed.raw", 5000);
+        await expect(build("seed", { filename }, destination)).rejects.toThrow(
+            "which is not a multiple of 4096",
+        );
+    });
+});

--- a/apps/cli/tests/integration/config.ts
+++ b/apps/cli/tests/integration/config.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import tmp from "tmp";
 import { DEFAULT_SDK_IMAGE, DEFAULT_SDK_VERSION } from "../../src/config.js";
 
-export const TEST_SDK = `${DEFAULT_SDK_IMAGE}:${DEFAULT_SDK_VERSION}`;
+// CARTESI_TEST_SDK points the suite at another image, e.g. one baked from packages/sdk
+export const TEST_SDK =
+    process.env.CARTESI_TEST_SDK ??
+    `${DEFAULT_SDK_IMAGE}:${DEFAULT_SDK_VERSION}`;
 
 /**
  * Ensures the required Docker image is available locally.

--- a/apps/cli/tests/integration/config.ts
+++ b/apps/cli/tests/integration/config.ts
@@ -42,7 +42,10 @@ export async function ensureDockerImage(image: string): Promise<void> {
  *
  * @returns {Promise<{ appDir: string, machineDir: string, cleanup: () => void }>}
  */
-export async function createTemporaryCartesiApplication(): Promise<{
+export async function createTemporaryCartesiApplication(options?: {
+    /** contents of a cartesi.toml written after create and before build */
+    config?: string;
+}): Promise<{
     appDir: string;
     machineDir: string;
     cleanup: () => void;
@@ -85,6 +88,11 @@ export async function createTemporaryCartesiApplication(): Promise<{
 
         //  Change directory into the created application
         process.chdir(appDir);
+
+        if (options?.config !== undefined) {
+            fs.writeFileSync(path.join(appDir, "cartesi.toml"), options.config);
+            console.log(`✓ Wrote a custom cartesi.toml`);
+        }
 
         console.log(`! Building the temporary Cartesi application...`);
 

--- a/apps/cli/tests/integration/exec/cartesi-machine-stored-hash.test.ts
+++ b/apps/cli/tests/integration/exec/cartesi-machine-stored-hash.test.ts
@@ -31,14 +31,15 @@ afterAll(() => {
 
 describe("cartesi-machine-stored-hash", () => {
     it("should return a computed hash", async () => {
-        const machineHash = await cartesiMachineStoredHash.computeHash(".", {
+        const machineHash = await cartesiMachineStoredHash.computeHash("./", {
             forceDocker: true,
             image: TEST_SDK,
             cwd: machineDir,
         });
 
         expect(machineHash).toBeDefined();
-        expect(isHash(machineHash!)).toBeTrue();
+        // @ts-expect-error - the above assertion ensures that machineHash is not undefined, so this type assertion is safe
+        expect(isHash(machineHash)).toBeTrue();
     });
 
     it("should return undefined for a non-existent machine directory", async () => {

--- a/apps/cli/tests/integration/exec/cartesi-machine-stored-hash.test.ts
+++ b/apps/cli/tests/integration/exec/cartesi-machine-stored-hash.test.ts
@@ -16,7 +16,9 @@ let cleanupTempApplication: () => void;
 beforeAll(
     async () => {
         await setupIntegrationTests();
-        const result = await createTemporaryCartesiApplication();
+        const result = await createTemporaryCartesiApplication({
+            config: `sdk = "${TEST_SDK}"`,
+        });
         machineDir = result.machineDir;
         cleanupTempApplication = result.cleanup;
     },

--- a/apps/cli/tests/integration/machine/nvram.test.ts
+++ b/apps/cli/tests/integration/machine/nvram.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import fs from "fs-extra";
+import path from "node:path";
+import { satisfies } from "semver";
+import { parse } from "../../../src/config.js";
+import { cartesiMachine } from "../../../src/exec/index.js";
+import { bootMachine } from "../../../src/machine.js";
+import {
+    createTemporaryCartesiApplication,
+    ensureDockerImage,
+    TEST_SDK,
+} from "../config.js";
+
+await ensureDockerImage(TEST_SDK);
+
+// --nvram only exists from cartesi-machine 0.21.0. gating on the version rather than on
+// CARTESI_TEST_SDK means this starts running on its own once DEFAULT_SDK_VERSION points at an
+// image that supports it.
+const found = await cartesiMachine.version({
+    image: TEST_SDK,
+    forceDocker: true,
+});
+
+const supported =
+    found !== null && satisfies(found.format(), cartesiMachine.requiredVersion);
+
+// sdk is set explicitly because bootMachine boots the image named by the config, not TEST_SDK
+const CONFIG = `sdk = "${TEST_SDK}"
+
+[nvrams.input]
+size = "4Ki"
+
+[nvrams.output]
+size = "4Ki"
+shared = true
+user = "dapp"
+` as const;
+
+describe.skipIf(!supported)("when booting a machine with nvrams", () => {
+    let app: Awaited<ReturnType<typeof createTemporaryCartesiApplication>>;
+    let context: string;
+
+    beforeAll(
+        async () => {
+            app = await createTemporaryCartesiApplication({ config: CONFIG });
+            context = path.join(app.appDir, ".cartesi");
+        },
+        { timeout: 60000 * 20 },
+    );
+
+    afterAll(() => {
+        app?.cleanup();
+    });
+
+    /**
+     * Boots the built application with a different entrypoint, the way the shell command does.
+     */
+    const boot = async (command: string) => {
+        const config = parse([CONFIG]);
+        config.machine.entrypoint = command;
+
+        // no interactive option, as -it needs a tty the test runner does not have
+        const { stdout } = await bootMachine(
+            config,
+            undefined,
+            {},
+            {
+                cwd: context,
+            },
+        );
+        return stdout as string;
+    };
+
+    it("should only build an image for the nvrams that need one", async () => {
+        const output = path.join(context, "output.raw");
+
+        expect(await fs.readFile(output)).toEqual(Buffer.alloc(4096));
+        // pristine, so cartesi-machine fills the range and there is nothing to build
+        expect(fs.existsSync(path.join(context, "input.raw"))).toBeFalsy();
+    });
+
+    it("should expose one uio device per nvram", async () => {
+        const stdout = await boot("ls /dev/uio*");
+
+        expect(stdout).toContain("/dev/uio0");
+        expect(stdout).toContain("/dev/uio1");
+        expect(stdout).not.toContain("/dev/uio2");
+    });
+
+    it("should resolve the labels in configuration order", async () => {
+        const stdout = await boot("nvram input; nvram output");
+
+        // the boot splash comes first, so keep only the lines the nvram tool printed
+        const devices = stdout
+            .split("\n")
+            .filter((line) => line.startsWith("/dev/uio"));
+        expect(devices).toEqual(["/dev/uio0", "/dev/uio1"]);
+    });
+
+    it("should round-trip through a shared nvram", async () => {
+        const stdout = await boot(
+            "echo hello-nvram | writemmap output; readmmap output | head -c 11",
+        );
+        expect(stdout).toContain("hello-nvram");
+
+        // shared, so the guest write reaches the backing image on the host
+        const image = await fs.readFile(path.join(context, "output.raw"));
+        expect(image.subarray(0, 11).toString()).toEqual("hello-nvram");
+    });
+});

--- a/apps/cli/tests/unit/config.test.ts
+++ b/apps/cli/tests/unit/config.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import {
     defaultConfig,
     defaultMachineConfig,
+    DuplicateLabelError,
     InvalidAddressValueError,
     InvalidBooleanValueError,
     InvalidBuilderError,
@@ -12,21 +13,24 @@ import {
     InvalidEmptyDriveFormatError,
     InvalidEnvError,
     InvalidNumberValueError,
+    InvalidNvramSizeError,
     InvalidStringValueError,
+    MissingNvramSourceError,
     parse,
     RequiredFieldError,
+    TooManyNvramsError,
 } from "../../src/config.js";
 
-const loadDriveConfig = (driveName: string) => {
-    const filePath = path.join(
-        __dirname,
-        "config",
-        "fixtures",
-        "drives",
-        `${driveName}.toml`,
-    );
+const loadFixture = (...segments: string[]) => {
+    const filePath = path.join(__dirname, "config", "fixtures", ...segments);
     return [fs.readFileSync(filePath, "utf-8")];
 };
+
+const loadDriveConfig = (driveName: string) =>
+    loadFixture("drives", `${driveName}.toml`);
+
+const loadNvramConfig = (nvramName: string) =>
+    loadFixture("nvrams", `${nvramName}.toml`);
 
 describe("when parsing only drive config files", () => {
     it("should pass with a basic drive config", () => {
@@ -57,6 +61,17 @@ describe("when parsing only drive config files", () => {
     it("should pass with a tar drive config", () => {
         const basic = loadDriveConfig("rives");
         expect(() => parse(basic)).not.toThrow();
+    });
+});
+
+describe("when parsing only nvram config files", () => {
+    it.each([
+        "pristine",
+        "shared",
+        "file",
+        "multi",
+    ])("should pass with a %s nvram config", (name) => {
+        expect(() => parse(loadNvramConfig(name))).not.toThrow();
     });
 });
 
@@ -517,6 +532,157 @@ shared = true`,
             expect(() =>
                 parse(["[drives.data]\nbuilder = 'empty'\nformat = 42"]),
             ).toThrowError(new InvalidEmptyDriveFormatError(42));
+        });
+    });
+
+    /**
+     * [nvrams]
+     */
+    describe("when parsing [nvrams]", () => {
+        it("should default to no nvrams", () => {
+            expect(parse([""]).nvrams).toEqual({});
+        });
+
+        it("should parse a pristine nvram", () => {
+            expect(parse(['[nvrams.input]\nsize = "4Ki"'])).toEqual({
+                ...defaultConfig(),
+                nvrams: {
+                    input: {
+                        filename: undefined,
+                        size: 4096,
+                        shared: undefined,
+                        user: undefined,
+                    },
+                },
+            });
+        });
+
+        it("should parse an nvram backed by an existing image", () => {
+            expect(parse(['[nvrams.seed]\nfilename = "./seed.raw"'])).toEqual({
+                ...defaultConfig(),
+                nvrams: {
+                    seed: {
+                        filename: "./seed.raw",
+                        size: undefined,
+                        shared: undefined,
+                        user: undefined,
+                    },
+                },
+            });
+        });
+
+        it("should parse a shared nvram", () => {
+            const config = `
+                [nvrams.output]
+                size = "4Ki"
+                shared = true
+                user = "dapp"
+            `;
+            expect(parse([config])).toEqual({
+                ...defaultConfig(),
+                nvrams: {
+                    output: {
+                        filename: undefined,
+                        size: 4096,
+                        shared: true,
+                        user: "dapp",
+                    },
+                },
+            });
+        });
+
+        it("should preserve the order of the nvrams", () => {
+            const config = `
+                [nvrams.output]
+                size = "4Ki"
+
+                [nvrams.input]
+                size = "4Ki"
+            `;
+            expect(Object.keys(parse([config]).nvrams)).toEqual([
+                "output",
+                "input",
+            ]);
+        });
+
+        it.each([
+            ["4096", 4096],
+            ['"4096"', 4096],
+            ['"4Ki"', 4096],
+            ['"4KiB"', 4096],
+            ['"4kb"', 4096],
+            ['"1Mi"', 1048576],
+            ['"1Mb"', 1048576],
+        ])("should parse size %s as %i bytes", (size, expected) => {
+            expect(
+                parse([`[nvrams.input]\nsize = ${size}`]).nvrams.input.size,
+            ).toEqual(expected);
+        });
+
+        it("should fail when neither size nor filename is defined", () => {
+            expect(() => parse(["[nvrams.input]"])).toThrowError(
+                new MissingNvramSourceError("input"),
+            );
+            expect(() => parse(["[nvrams.input]\nshared = true"])).toThrowError(
+                new MissingNvramSourceError("input"),
+            );
+        });
+
+        it("should fail for a size that is not a multiple of 4Ki", () => {
+            expect(() => parse(['[nvrams.input]\nsize = "5Ki"'])).toThrowError(
+                new InvalidNvramSizeError("input", 5120),
+            );
+            expect(() => parse(["[nvrams.input]\nsize = 0"])).toThrowError(
+                new InvalidNvramSizeError("input", 0),
+            );
+        });
+
+        it("should fail for an unparseable size", () => {
+            expect(() => parse(['[nvrams.input]\nsize = "abc"'])).toThrowError(
+                new InvalidBytesValueError("abc"),
+            );
+            expect(() => parse(["[nvrams.input]\nsize = true"])).toThrowError(
+                new InvalidBytesValueError(true),
+            );
+        });
+
+        it("should fail for more than 8 nvrams", () => {
+            const config = Array.from(
+                { length: 9 },
+                (_, i) => `[nvrams.n${i}]\nsize = "4Ki"`,
+            ).join("\n");
+            expect(() => parse([config])).toThrowError(
+                new TooManyNvramsError(9),
+            );
+        });
+
+        it("should fail when a label is used by both a drive and an nvram", () => {
+            const config = `
+                [drives.data]
+                builder = "empty"
+                size = "100Mb"
+
+                [nvrams.data]
+                size = "4Ki"
+            `;
+            expect(() => parse([config])).toThrowError(
+                new DuplicateLabelError("data"),
+            );
+        });
+
+        it("should fail for the root label, which is always a drive", () => {
+            expect(() => parse(['[nvrams.root]\nsize = "4Ki"'])).toThrowError(
+                new DuplicateLabelError("root"),
+            );
+        });
+
+        it("should fail for invalid shared and user values", () => {
+            expect(() =>
+                parse(['[nvrams.input]\nsize = "4Ki"\nshared = 42']),
+            ).toThrowError(new InvalidBooleanValueError(42));
+            expect(() =>
+                parse(['[nvrams.input]\nsize = "4Ki"\nuser = 42']),
+            ).toThrowError(new InvalidStringValueError(42));
         });
     });
 

--- a/apps/cli/tests/unit/config/fixtures/full.toml
+++ b/apps/cli/tests/unit/config/fixtures/full.toml
@@ -49,6 +49,23 @@
 # filename = "./games/doom.sqfs"
 # mount = "/usr/local/games/doom"
 
+# nvrams are raw byte ranges exposed to the guest as /dev/uio0 to /dev/uio7 (up to 8 of them).
+# unlike drives they have no filesystem and no mount point, so the guest reads and writes them
+# with the readmmap/writemmap tools from machine-guest-tools. requires cartesi-machine 0.21.0.
+# an nvram label cannot be the same as a drive label.
+
+# [nvrams.input]
+# size = "4Ki" # required unless 'filename' is given. must be a multiple of 4Ki
+
+# [nvrams.output]
+# size = "4Ki"
+# shared = true # guest writes are persisted to .cartesi/output.raw, which the next build wipes
+# user = "dapp" # optional. allows the unprivileged entrypoint user to write to it
+
+# [nvrams.seed]
+# filename = "./seed.raw" # existing raw image. it is copied into .cartesi/, never written to
+# size = "4Ki" # optional. when given it must match the size of the file exactly
+
 # [withdrawal.config]
 # guardian = "0x1111111111111111111111111111111111111111" 
 # log2_leaves_per_account = 0

--- a/apps/cli/tests/unit/config/fixtures/nvrams/file.toml
+++ b/apps/cli/tests/unit/config/fixtures/nvrams/file.toml
@@ -1,0 +1,5 @@
+# example of an nvram whose initial contents come from an existing raw image
+# size is optional here, as it defaults to the size of the file
+
+[nvrams.seed]
+filename = "./seed.raw"

--- a/apps/cli/tests/unit/config/fixtures/nvrams/multi.toml
+++ b/apps/cli/tests/unit/config/fixtures/nvrams/multi.toml
@@ -1,0 +1,10 @@
+# example of an application reading an input nvram and writing an output one
+# the order of the tables is the order of the /dev/uio* devices in the guest
+
+[nvrams.input]
+size = "4Ki"
+
+[nvrams.output]
+size = "4Ki"
+shared = true
+user = "dapp"

--- a/apps/cli/tests/unit/config/fixtures/nvrams/pristine.toml
+++ b/apps/cli/tests/unit/config/fixtures/nvrams/pristine.toml
@@ -1,0 +1,5 @@
+# example of a pristine nvram, filled with zeros by cartesi-machine
+# no image is built for it, as there is nothing to persist
+
+[nvrams.input]
+size = "4Ki" # must be a multiple of 4Ki

--- a/apps/cli/tests/unit/config/fixtures/nvrams/shared.toml
+++ b/apps/cli/tests/unit/config/fixtures/nvrams/shared.toml
@@ -1,0 +1,7 @@
+# example of an nvram the guest writes its output to
+# shared makes the writes land on .cartesi/output.raw, and user lets the entrypoint user write
+
+[nvrams.output]
+size = "4Ki"
+shared = true
+user = "dapp"

--- a/apps/cli/tests/unit/exec/cartesi-machine.test.ts
+++ b/apps/cli/tests/unit/exec/cartesi-machine.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { parse, satisfies, type SemVer } from "semver";
+import {
+    requiredVersion,
+    UnsupportedVersionError,
+} from "../../../src/exec/cartesi-machine.js";
+
+describe("requiredVersion", () => {
+    it.each(["0.21.0", "0.21.3"])("should accept %s", (version) => {
+        expect(satisfies(version, requiredVersion)).toBeTruthy();
+    });
+
+    it.each([
+        "0.20.0",
+        "0.20.9",
+        "0.22.0",
+        "1.0.0",
+    ])("should reject %s", (version) => {
+        expect(satisfies(version, requiredVersion)).toBeFalsy();
+    });
+});
+
+describe("UnsupportedVersionError", () => {
+    it("should name the version found and the range required", () => {
+        const error = new UnsupportedVersionError(parse("0.20.0") as SemVer);
+        expect(error.message).toEqual(
+            `cartesi-machine 0.20.0 found, but ${requiredVersion.raw} is required`,
+        );
+    });
+});

--- a/apps/cli/tests/unit/machine.test.ts
+++ b/apps/cli/tests/unit/machine.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { parse } from "../../src/config.js";
+import { buildMachineArgs } from "../../src/machine.js";
+
+const argsOf = (toml: string) =>
+    buildMachineArgs(
+        parse([`[machine]\nentrypoint = "/bin/sh"\n${toml}`]),
+        undefined,
+        {},
+    );
+
+const nvramArgs = (toml: string) =>
+    argsOf(toml).filter((arg) => arg.startsWith("--nvram="));
+
+describe("buildMachineArgs", () => {
+    it("should not emit any --nvram when none is configured", () => {
+        expect(nvramArgs("")).toEqual([]);
+    });
+
+    it("should emit length only for a pristine nvram", () => {
+        expect(nvramArgs('[nvrams.input]\nsize = "4Ki"')).toEqual([
+            "--nvram=label:input,length:4096",
+        ]);
+    });
+
+    it("should emit a data_filename for a shared nvram", () => {
+        const toml = `
+            [nvrams.output]
+            size = "4Ki"
+            shared = true
+            user = "dapp"
+        `;
+        expect(nvramArgs(toml)).toEqual([
+            "--nvram=label:output,length:4096,data_filename:output.raw,user:dapp,shared",
+        ]);
+    });
+
+    it("should omit length for an nvram backed by an existing image", () => {
+        expect(nvramArgs('[nvrams.seed]\nfilename = "./seed.raw"')).toEqual([
+            "--nvram=label:seed,data_filename:seed.raw",
+        ]);
+    });
+
+    it("should emit both length and data_filename when both are defined", () => {
+        const toml = `
+            [nvrams.seed]
+            filename = "./seed.raw"
+            size = "4Ki"
+        `;
+        expect(nvramArgs(toml)).toEqual([
+            "--nvram=label:seed,length:4096,data_filename:seed.raw",
+        ]);
+    });
+
+    it("should emit nvrams after all flash drives, in configuration order", () => {
+        const toml = `
+            [nvrams.output]
+            size = "4Ki"
+
+            [nvrams.input]
+            size = "4Ki"
+        `;
+        const args = argsOf(toml);
+        const lastFlashDrive = args.reduce(
+            (last, arg, index) =>
+                arg.startsWith("--flash-drive=") ? index : last,
+            -1,
+        );
+        const firstNvram = args.findIndex((arg) => arg.startsWith("--nvram="));
+
+        expect(lastFlashDrive).toBeGreaterThanOrEqual(0);
+        expect(firstNvram).toBeGreaterThan(lastFlashDrive);
+        expect(nvramArgs(toml)).toEqual([
+            "--nvram=label:output,length:4096",
+            "--nvram=label:input,length:4096",
+        ]);
+    });
+});

--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -1,1 +1,4 @@
 build.json
+# Downloaded by fetch.sh — not versioned.
+temp/*.deb
+temp/artifacts.zip

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -70,8 +70,8 @@ mkdir -p /usr/local/bin
 curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz \
   -o /tmp/foundry.tar.gz
 case "${TARGETARCH}" in
-    amd64) echo "73640b01bd9ed29fdb4965085099371f8cf0dbbec3e2086cf54564efc4dcfe88 /tmp/foundry.tar.gz" | sha256sum --check ;;
-    arm64) echo "cccf28bdf202289e837a9e21ed213b2b80dc1e806e12f1717bc98a44315c331e /tmp/foundry.tar.gz" | sha256sum --check ;;
+    amd64) echo "325ba04dc5cb41c110723b00ac291f8269f8cd785028299aad8252ef980961a7 /tmp/foundry.tar.gz" | sha256sum --check ;;
+    arm64) echo "209492cb4ebd723d9eac002fa30f41f53c8810105b67d3c32fe8201cf70f89d4 /tmp/foundry.tar.gz" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
 tar -zx -f /tmp/foundry.tar.gz -C /usr/local/bin
@@ -198,16 +198,18 @@ cartesi-machine --version-json
 EOF
 
 # Install cartesi-rollups-node
-RUN <<EOF
-curl -fsSL https://github.com/cartesi/rollups-node/releases/download/v${CARTESI_ROLLUPS_NODE_VERSION}/cartesi-rollups-node-v${CARTESI_ROLLUPS_NODE_VERSION}_${TARGETARCH}.deb \
-    -o /tmp/cartesi-rollups-node.deb
+# TEMPORARY: install from the .deb fetched into temp/ by temp/fetch.sh, built by
+# https://github.com/cartesi/rollups-node/actions/runs/31189416046 (artifact "artifacts").
+# The published v2.0.0-alpha.12 release carries the same version string but different, includes emulator 0.21.0.
+# The checksums below are also pinned in temp/fetch.sh; update both together.
+RUN --mount=type=bind,source=temp,target=/debs <<EOF
+DEB=/debs/cartesi-rollups-node-v${CARTESI_ROLLUPS_NODE_VERSION}_${TARGETARCH}.deb
 case "${TARGETARCH}" in
-    amd64) echo "b2db03fcab1453238346fe6638b50693a405659fd73fe3ddca5be8d4e950528a /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
-    arm64) echo "e080a25f19f04b3d2164354c49989dcd72c02af6866623a70816eb08f0d75490 /tmp/cartesi-rollups-node.deb" | sha256sum --check ;;
+    amd64) echo "6ab8bf675e4d2a3bc3e8d14521c2b2fb0ecc291fc26474f4b3c0db6d9e800a7b  ${DEB}" | sha256sum --check ;;
+    arm64) echo "d3c4876d2c4de7578755ad67255cac303ea6e677bd8f182e8df22f1b41d81063  ${DEB}" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
-apt-get install -y --no-install-recommends /tmp/cartesi-rollups-node.deb
-rm /tmp/cartesi-rollups-node.deb
+apt-get install -y --no-install-recommends "${DEB}"
 mkdir -p /var/lib/cartesi-rollups-node/snapshots
 chmod 755 /var/lib/cartesi-rollups-node/snapshots
 chown cartesi:cartesi /var/lib/cartesi-rollups-node/snapshots

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -70,8 +70,8 @@ mkdir -p /usr/local/bin
 curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz \
   -o /tmp/foundry.tar.gz
 case "${TARGETARCH}" in
-    amd64) echo "325ba04dc5cb41c110723b00ac291f8269f8cd785028299aad8252ef980961a7 /tmp/foundry.tar.gz" | sha256sum --check ;;
-    arm64) echo "209492cb4ebd723d9eac002fa30f41f53c8810105b67d3c32fe8201cf70f89d4 /tmp/foundry.tar.gz" | sha256sum --check ;;
+    amd64) echo "73640b01bd9ed29fdb4965085099371f8cf0dbbec3e2086cf54564efc4dcfe88 /tmp/foundry.tar.gz" | sha256sum --check ;;
+    arm64) echo "cccf28bdf202289e837a9e21ed213b2b80dc1e806e12f1717bc98a44315c331e /tmp/foundry.tar.gz" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
 tar -zx -f /tmp/foundry.tar.gz -C /usr/local/bin

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -14,9 +14,9 @@ target "default" {
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.21.0"
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
-    CARTESI_PRT_VERSION               = "3.0.0-alpha.3"
+    CARTESI_PRT_VERSION               = "3.0.0-alpha.4"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.12"
-    FOUNDRY_VERSION                   = "1.4.3"
+    FOUNDRY_VERSION                   = "1.5.1"
     NITRO_VERSION                     = "c937fa4fd202074dd250086ebd92de6884968b84" # v0.8.1
     NODE_VERSION                      = "24.14.0"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -14,9 +14,9 @@ target "default" {
     CARTESI_MACHINE_EMULATOR_VERSION  = "0.21.0"
     CARTESI_PASSKEY_SERVER_VERSION    = "1.0.1"
     CARTESI_PAYMASTER_VERSION         = "0.2.0"
-    CARTESI_PRT_VERSION               = "3.0.0-alpha.4"
+    CARTESI_PRT_VERSION               = "3.0.0-alpha.3"
     CARTESI_ROLLUPS_NODE_VERSION      = "2.0.0-alpha.12"
-    FOUNDRY_VERSION                   = "1.5.1"
+    FOUNDRY_VERSION                   = "1.4.3"
     NITRO_VERSION                     = "c937fa4fd202074dd250086ebd92de6884968b84" # v0.8.1
     NODE_VERSION                      = "24.14.0"
     NVM_VERSION                       = "977563e97ddc66facf3a8e31c6cff01d236f09bd" # 0.40.3

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "version": "0.12.0-alpha.41",
     "scripts": {
-        "build": "docker buildx bake --load --metadata-file=build.json"
+        "fetch:temp": "./temp/fetch.sh",
+        "build": "bun run fetch:temp && docker buildx bake --load --metadata-file=build.json"
     }
 }

--- a/packages/sdk/temp/fetch.sh
+++ b/packages/sdk/temp/fetch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# TEMPORARY: fetch the cartesi-rollups-node .deb files the SDK image installs.
+#
+# These come from an unreleased build:
+# https://github.com/cartesi/rollups-node/actions/runs/31189416046
+# (branch feature/bump-emulator-v0.21.0). The published v2.0.0-alpha.12 release carries the
+# same version string but different binaries, so it cannot be used. Delete this folder once a
+# release with these builds exists.
+#
+# nightly.link proxies the artifact without authentication (the GitHub API requires a token
+# even for public repos). The artifact expires 2026-11-05, after which this script stops
+# working and the SDK image can no longer be built.
+#
+# Run via `bun run fetch:temp`; `bun run build` calls it first. The download is skipped when
+# both .deb files are already present *and* match the checksums pinned below — set FORCE=1 to
+# refetch unconditionally. The same checksums are pinned in the Dockerfile, which re-verifies
+# at install time; update both together.
+set -euo pipefail
+
+RUN_ID=31189416046
+VERSION=2.0.0-alpha.12
+SHA256_AMD64=6ab8bf675e4d2a3bc3e8d14521c2b2fb0ecc291fc26474f4b3c0db6d9e800a7b
+SHA256_ARM64=d3c4876d2c4de7578755ad67255cac303ea6e677bd8f182e8df22f1b41d81063
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CHECKSUMS="${SHA256_AMD64}  ${DIR}/cartesi-rollups-node-v${VERSION}_amd64.deb
+${SHA256_ARM64}  ${DIR}/cartesi-rollups-node-v${VERSION}_arm64.deb"
+
+# A present-but-corrupt file fails the check and falls through to a refetch.
+if [ "${FORCE:-0}" != "1" ] && printf '%s\n' "${CHECKSUMS}" | shasum -a 256 --check --status 2>/dev/null; then
+    echo "cartesi-rollups-node v${VERSION} .deb files already present and verified, skipping download."
+    exit 0
+fi
+
+curl -fL --progress-bar \
+    "https://nightly.link/cartesi/rollups-node/actions/runs/${RUN_ID}/artifacts.zip" \
+    -o "${DIR}/artifacts.zip"
+
+# The archive holds both debs at the root, already correctly named.
+unzip -o -j "${DIR}/artifacts.zip" "cartesi-rollups-node-v${VERSION}_*.deb" -d "${DIR}"
+rm "${DIR}/artifacts.zip"
+
+printf '%s\n' "${CHECKSUMS}" | shasum -a 256 --check


### PR DESCRIPTION
## Summary

Code changes to add NVRAM support to the CLI, on top of the emulator 0.21.0 bump from `refactor/sdk-update-anvil-state-source` (this PR is stacked on that branch).

An NVRAM is a raw range of bytes exposed to the guest as a `/dev/uio*` device through the generic-uio driver. Unlike a flash drive it has no filesystem, no mount point and no page cache between the guest and the memory range, so writes are immediately visible to the emulator with no flush before snapshotting. That makes it the right primitive for an application that wants a fixed region of bytes it can `mmap()` and persist across advance states.

## The new cartesi.toml config

`[nvrams]` is entirely optional — a `cartesi.toml` without it behaves exactly as before, emits no new flags and runs no new build steps.

```toml
[nvrams.input]
size = "4Ki"              # pristine, filled with zeros by cartesi-machine

[nvrams.output]
size = "4Ki"
shared = true             # guest writes are persisted to .cartesi/output.raw
user = "dapp"             # let the unprivileged entrypoint user write to it

[nvrams.seed]
filename = "./seed.raw"   # existing raw image; size defaults to the file size
```

Each table must define `size` or `filename` (or both, in which case they must agree exactly). Sizes must be a multiple of 4Ki, at most 8 nvrams are supported (`/dev/uio0` to `/dev/uio7`), and labels cannot collide with drive labels since both share the DTB `/aliases` namespace. These are validated at parse time, so a bad `cartesi.toml` fails before anything is built.

Translation to the emulator, in `cartesi.toml` order:

| configuration | flag |
|---|---|
| `size = "4Ki"` | `--nvram=label:input,length:4096` |
| `size`, `shared`, `user` | `--nvram=label:output,length:4096,data_filename:output.raw,user:dapp,shared` |
| `filename = "./seed.raw"` | `--nvram=label:seed,data_filename:seed.raw` |

Only nvrams that need a backing image get a build step: a `shared` one is allocated zero-filled in `.cartesi/`, and a `filename` one is copied there (never written back to the source). A pristine nvram produces no artifact at all, since the emulator zero-fills the range itself.

Documented in `apps/cli/tests/unit/config/fixtures/full.toml`, the de-facto reference for `cartesi.toml`.

### Permissions

`user = "dapp"` is what makes an nvram writable by the application, since entrypoints run unprivileged. Leaving it off gives a root-owned device node — readable by the app, not writable:

```
crw-rw-r-- 1 root root  /dev/uio0    # [nvrams.input]  — no user
crw-rw-r-- 1 dapp dapp  /dev/uio1    # [nvrams.output] — user = "dapp"
```

That is least-privilege hygiene, not an integrity guarantee: booting with `--user=root` (or `cartesi shell --run-as-root`) writes it fine.

## Behaviour change: cartesi-machine 0.21.0 is now required

`--nvram` does not exist before 0.21.0, so `requiredVersion` moves from `^0.20.0` to `^0.21.0`.

That constant used to be declarative only — nothing read it at runtime and `doctor` never checked the emulator. Since a host-installed `cartesi-machine` silently takes precedence over the SDK image (the Docker fallback only triggers on `ENOENT`), a user on 0.20.0 would have got:

```
lua5.4: /usr/share/lua/5.4/cartesi-machine.lua:1956: unrecognized option --nvram=label:input,length:4096
stack traceback: ...
```

So the range is now enforced. `build` and `shell` check before booting, and `doctor` reports it alongside the Docker checks:

```
✖ Unsupported Cartesi Machine version. Required version is ^0.21.0. Installed version is 0.20.0.
✔ Cartesi Machine 0.21.0
```

The check is deliberately non-blocking when the version cannot be determined at all — that also happens when Docker is down or the binary is missing, and the boot that follows reports those on its own.

## Also included

- **`fix(cli)`** — the cartesi-machine version check ignored its `forceDocker` option, silently
  reading the host binary instead of the SDK image. This is why the version assertion in
  `cartesi-machine.test.ts` passed for anyone with a matching local install and failed in CI.
- **`test(cli)`** — `CARTESI_TEST_SDK` overrides the image the integration suite runs against, so
  it can target an SDK image built from source instead of the released tag.
- **`test(cli)`** — `cartesi-machine-stored-hash` no longer prefixes the emulator output with `0x`,
  which 0.21.0 already includes.
- **`test(cli)`** — a boot-level nvram integration test, plus an optional `cartesi.toml` argument on
  `createTemporaryCartesiApplication` so a test can build an application that declares nvrams.
- **`refactor(cli)`** — argument assembly split out of `bootMachine` into a pure `buildMachineArgs`,
  so the generated flags can be unit tested without spawning a machine.

## Testing

Coverage is layered so that each level tests something the CLI actually owns.

| level | file | covers |
|---|---|---|
| unit | `tests/unit/config.test.ts` | `[nvrams]` parsing, IEC sizes, every validation error |
| unit | `tests/unit/machine.test.ts` | the exact `--nvram=` strings and their order relative to `--flash-drive` |
| unit | `tests/unit/exec/cartesi-machine.test.ts` | the version range and its error message |
| integration | `tests/integration/builder/nvram.test.ts` | the backing images on disk |
| integration | `tests/integration/machine/nvram.test.ts` | a real machine booting with nvrams |

The boot test builds a throwaway application whose `cartesi.toml` declares a pristine `input` and a
shared `output`, then boots it with replacement entrypoints the way `shell` does, and asserts:

- only the nvrams that need a backing image get one — `output.raw` is 4096 zero bytes, `input.raw`
  is absent;
- the guest exposes one `/dev/uio*` per nvram and no more;
- `nvram input` / `nvram output` resolve in `cartesi.toml` order, which is the ordering the CLI is
  responsible for;
- `echo hello-nvram | writemmap output; readmmap output` round-trips, **and** the bytes reach the
  host's `.cartesi/output.raw` — the assertion that actually proves `shared` works. Drop
  `shared = true` and only that last assertion fails.

_It is gated on the emulator supporting `--nvram` (`describe.skipIf` on a version probe) rather than
on `CARTESI_TEST_SDK` being set, so it skips cleanly today and starts running by itself once
`DEFAULT_SDK_VERSION` points at a 0.21.0 image. In CI it runs, because the temporary commit below
points `CARTESI_TEST_SDK` at the PR-tagged SDK image._

## Merge blocker

`DEFAULT_SDK_VERSION` is still `0.12.0-alpha.41`, and that published image ships emulator 0.20.0. Until an SDK release carrying 0.21.0 exists and the default is bumped to it, anyone on the default image gets the new version error. **This PR should not merge before that bump**, either as a final commit here or as an immediately following PR.

## ⚠️ Temporary support test / ci-builds — (Must be removed before merging)

<details>

<summary><h2>Commit details</h2></summary>

The last commit, `wip(cli): Temporary changes to support local/ci builds and test runs`, exists only so this branch can be built and tested before its dependencies are released. **It must be dropped before merge.** It is deliberately isolated in a single commit so it can be removed with a single revert or drop.

It exists because the SDK image needs a `cartesi-rollups-node` build compiled against emulator 0.21.0, and no release contains one. The published `v2.0.0-alpha.12` carries the same version string but different binaries, so it cannot be used.

What it changes:

- **`packages/sdk/temp/fetch.sh`** (new) — downloads the `cartesi-rollups-node` `.deb` files from an
  unreleased Actions run (`cartesi/rollups-node` run `31189416046`, branch
  `feature/bump-emulator-v0.21.0`) via nightly.link, which proxies the artifact without
  authentication. Checksums are pinned and verified; the download is skipped when the files are
  already present and valid.
- **`packages/sdk/Dockerfile`** — installs `cartesi-rollups-node` from that bind-mounted `.deb`
  instead of the release URL, with the corresponding checksums.
- **`packages/sdk/package.json`** — `build` now runs `fetch:temp` first.
- **`packages/sdk/.gitignore`** — ignores the downloaded `temp/*.deb` and `temp/artifacts.zip`.
- **`.github/workflows/sdk.yaml`** — runs `./temp/fetch.sh` before the bake.
- **`.github/workflows/cli.yaml`** — adds `packages/sdk/**` to the path filter, sets
  `CARTESI_TEST_SDK` to the PR-tagged SDK image `ghcr.io/cartesi/sdk:pr-<N>` that `sdk.yaml`
  publishes for this PR, and logs in to ghcr.io to pull it. This is what makes CI exercise the
  integration suite against an emulator that actually supports `--nvram`.
- **`packages/sdk/docker-bake.hcl` and the foundry checksums in the Dockerfile** — ⚠️ this **reverts
  base-branch changes**: `FOUNDRY_VERSION` back from `1.5.1` to `1.4.3` and `CARTESI_PRT_VERSION`
  back from `3.0.0-alpha.4` to `3.0.0-alpha.3`, because the unreleased rollups-node build expects
  them. Dropping the commit restores the base values — take care not to lose them by resolving a
  conflict the wrong way.

</details>

> Two deadlines worth knowing: the Actions artifact **expires 2026-11-05**, after which the SDK image can no longer be built from this branch, and until then `bun run build` in `packages/sdk` requires network access to nightly.link.

Removal checklist:

- [ ] Drop commit `wip(cli): Temporary changes to support local/ci builds and test runs`
- [ ] Confirm `docker-bake.hcl` is back to `FOUNDRY_VERSION = "1.5.1"` and `CARTESI_PRT_VERSION = "3.0.0-alpha.4"`
- [ ] Confirm the Dockerfile installs `cartesi-rollups-node` from the release URL again
- [ ] Confirm `packages/sdk/temp/` is gone and both workflows are unmodified
- [ ] Bump `DEFAULT_SDK_VERSION` to the SDK release shipping emulator 0.21.0
- [ ] Re-check that the nvram boot test runs (not skips) once the default SDK carries 0.21.0