### PR TITLE
refactor(cli): generate contracts with @cartesi/wagmi-plugin

### DIFF
--- a/.changeset/busy-bags-sing.md
+++ b/.changeset/busy-bags-sing.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Add `TestUsdc` to the devnet address book, and `RefundOutputBuilder` and `UsdWithdrawalOutputBuilderFactory` to the common one.

--- a/.changeset/thick-experts-notice.md
+++ b/.changeset/thick-experts-notice.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/cli": patch
+---
+
+Generate contracts from the rollups-contracts release instead of `@cartesi/devnet`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,8 +42,7 @@
         "yaml": "^2.8.2"
     },
     "devDependencies": {
-        "@cartesi/devnet": "2.0.0-alpha.14",
-        "@sunodo/wagmi-plugin-hardhat-deploy": "^0.4.0",
+        "@cartesi/wagmi-plugin": "1.0.0-alpha.6",
         "@types/bun": "^1.3.6",
         "@types/bytes": "^3.1.5",
         "@types/fs-extra": "^11.0.4",

--- a/apps/cli/src/base.ts
+++ b/apps/cli/src/base.ts
@@ -22,11 +22,14 @@ import {
     erc721PortalAddress,
     etherPortalAddress,
     inputBoxAddress,
+    refundOutputBuilderAddress,
     selfHostedApplicationFactoryAddress,
     testFungibleTokenAddress,
     testMultiTokenAddress,
     testNonFungibleTokenAddress,
+    testUsdcAddress,
     testUsdWithdrawalOutputBuilderAddress,
+    usdWithdrawalOutputBuilderFactoryAddress,
 } from "./contracts.js";
 import { cartesiMachineStoredHash } from "./exec";
 import { getApplicationAddress, getForkConfig } from "./exec/rollups.js";
@@ -118,6 +121,7 @@ export const getAddressBook = async (options: {
         TestToken: testFungibleTokenAddress,
         TestNFT: testNonFungibleTokenAddress,
         TestMultiToken: testMultiTokenAddress,
+        TestUsdc: testUsdcAddress,
         TestUsdWithdrawalOutputBuilder: testUsdWithdrawalOutputBuilderAddress,
     };
 
@@ -132,7 +136,10 @@ export const getAddressBook = async (options: {
         ERC721Portal: erc721PortalAddress,
         EtherPortal: etherPortalAddress,
         InputBox: inputBoxAddress,
+        RefundOutputBuilder: refundOutputBuilderAddress,
         SelfHostedApplicationFactory: selfHostedApplicationFactoryAddress,
+        UsdWithdrawalOutputBuilderFactory:
+            usdWithdrawalOutputBuilderFactoryAddress,
     };
 
     // gather all contracts, depending whether is fork or devnet

--- a/apps/cli/wagmi.config.ts
+++ b/apps/cli/wagmi.config.ts
@@ -1,11 +1,7 @@
-import hardhatDeploy from "@sunodo/wagmi-plugin-hardhat-deploy";
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
 import { defineConfig } from "@wagmi/cli";
 
 export default defineConfig({
     out: "src/contracts.ts",
-    plugins: [
-        hardhatDeploy({
-            directory: "node_modules/@cartesi/devnet/deployments",
-        }),
-    ],
+    plugins: [rollupsContracts({ prt: true })],
 });

--- a/bun.lock
+++ b/bun.lock
@@ -45,8 +45,7 @@
         "yaml": "^2.8.2",
       },
       "devDependencies": {
-        "@cartesi/devnet": "2.0.0-alpha.14",
-        "@sunodo/wagmi-plugin-hardhat-deploy": "^0.4.0",
+        "@cartesi/wagmi-plugin": "1.0.0-alpha.6",
         "@types/bun": "^1.3.6",
         "@types/bytes": "^3.1.5",
         "@types/fs-extra": "^11.0.4",
@@ -144,6 +143,8 @@
     "@cartesi/mock-verifying-paymaster": ["@cartesi/mock-verifying-paymaster@workspace:packages/mock-verifying-paymaster"],
 
     "@cartesi/sdk": ["@cartesi/sdk@workspace:packages/sdk"],
+
+    "@cartesi/wagmi-plugin": ["@cartesi/wagmi-plugin@1.0.0-alpha.6", "", { "dependencies": { "abitype": "^1.3.0", "modern-tar": "^0.8.4" }, "peerDependencies": { "@wagmi/cli": "^2.10.0", "viem": "^2.0.0" } }, "sha512-xUrgLp4nBlMUu0iYsVYfH2brRYdhTwLa8mycHR2oc33WXtTZmLxZ+gppUjkZHCb6wPIBM8ezGhoP2UgsqTeQMg=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.14", "", { "dependencies": { "@changesets/config": "3.1.2", "@changesets/get-version-range-type": "0.4.0", "@changesets/git": "3.0.4", "@changesets/should-skip-package": "0.1.2", "@changesets/types": "6.1.0", "@manypkg/get-packages": "1.1.3", "detect-indent": "6.1.0", "fs-extra": "7.0.1", "lodash.startcase": "4.4.0", "outdent": "0.5.0", "prettier": "2.8.8", "resolve-from": "5.0.0", "semver": "7.7.2" } }, "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA=="],
 
@@ -351,8 +352,6 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@sunodo/wagmi-plugin-hardhat-deploy": ["@sunodo/wagmi-plugin-hardhat-deploy@0.4.0", "", { "peerDependencies": { "@wagmi/core": ">=2.0.0", "abitype": ">=0.10.0", "typescript": ">=5.0.4", "wagmi": ">=2.0.0" }, "optionalPeers": ["@wagmi/core", "typescript", "wagmi"] }, "sha512-kZvhu6ZGNpIvXbV8uZIwUspyEKhXuP8B0TKsM5Pve1eEvwtGZuNwKgW2BZXLZCwjGIRXBK9g/48p+Iy7RRBAww=="],
-
     "@tsconfig/node10": ["@tsconfig/node10@1.0.12", "", {}, "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ=="],
 
     "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
@@ -389,7 +388,7 @@
 
     "@wagmi/cli": ["@wagmi/cli@2.10.0", "", { "dependencies": { "abitype": "^1.1.1", "bundle-require": "^5.1.0", "cac": "^6.7.14", "change-case": "^5.4.4", "chokidar": "4.0.1", "dedent": "^0.7.0", "dotenv": "^16.3.1", "dotenv-expand": "^10.0.0", "esbuild": "~0.25.4", "escalade": "3.2.0", "fdir": "^6.1.1", "nanospinner": "1.2.2", "pathe": "^1.1.2", "picocolors": "^1.0.0", "picomatch": "^3.0.0", "prettier": "^3.0.3", "viem": "2.x", "zod": "^4.1.11" }, "peerDependencies": { "typescript": ">=5.7.3" }, "optionalPeers": ["typescript"], "bin": { "wagmi": "dist/esm/cli.js" } }, "sha512-2tYt6Bp1q26mWexH+XE6dMpPB5/Gp/3OVtE2SeeJ/gNHKLZmVF/TuoZR75mpJKTpofyvpz/fnuMCkUxzbc/kRw=="],
 
-    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+    "abitype": ["abitype@1.3.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg=="],
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
@@ -809,7 +808,7 @@
 
     "mnemonist": ["mnemonist@0.39.6", "", { "dependencies": { "obliterator": "^2.0.1" } }, "sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA=="],
 
-    "modern-tar": ["modern-tar@0.7.3", "", {}, "sha512-4W79zekKGyYU4JXVmB78DOscMFaJth2gGhgfTl2alWE4rNe3nf4N2pqenQ0rEtIewrnD79M687Ouba3YGTLOvg=="],
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -818,8 +817,6 @@
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
-
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 
@@ -906,8 +903,6 @@
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
-
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
@@ -1016,8 +1011,6 @@
     "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
-
-    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "7.0.6", "signal-exit": "4.1.0" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
@@ -1167,9 +1160,11 @@
 
     "zod-validation-error": ["zod-validation-error@3.5.4", "", { "peerDependencies": { "zod": "^3.24.4" } }, "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw=="],
 
-    "@cartesi/cli/@cartesi/devnet": ["@cartesi/devnet@2.0.0-alpha.14", "", {}, "sha512-BPcFh1NBauZlpoL6HedBL88xvi5D+PweAUlxKSxNEiBCE8sJDx8TaTiwKtnSH27l6r4NuuZTeClgWBOq8e+Taw=="],
+    "@cartesi/devnet/modern-tar": ["modern-tar@0.7.3", "", {}, "sha512-4W79zekKGyYU4JXVmB78DOscMFaJth2gGhgfTl2alWE4rNe3nf4N2pqenQ0rEtIewrnD79M687Ouba3YGTLOvg=="],
 
     "@cartesi/mock-verifying-paymaster/viem": ["viem@2.18.4", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.0", "@noble/curves": "1.4.0", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0", "abitype": "1.0.5", "isows": "1.0.4", "webauthn-p256": "0.0.5", "ws": "8.17.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-JGdN+PgBnZMbm7fc9o0SfHvL0CKyfrlhBUtaz27V+PeHO43Kgc9Zd4WyIbM8Brafq4TvVcnriRFW/FVGOzwEJw=="],
+
+    "@cartesi/wagmi-plugin/modern-tar": ["modern-tar@0.8.4", "", {}, "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g=="],
 
     "@changesets/apply-release-plan/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "4.2.11", "jsonfile": "4.0.0", "universalify": "0.1.2" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
@@ -1219,6 +1214,8 @@
 
     "@types/through/@types/node": ["@types/node@24.5.1", "", { "dependencies": { "undici-types": "7.12.0" } }, "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q=="],
 
+    "@wagmi/cli/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
     "@wagmi/cli/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "ajv/fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
@@ -1257,9 +1254,9 @@
 
     "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
-    "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+    "ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
-    "permissionless/viem": ["viem@2.43.5", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-QuJpuEMEPM3EreN+vX4mVY68Sci0+zDxozYfbh/WfV+SSy/Gthm74PH8XmitXdty1xY54uTCJ+/Gbbd1IiMPSA=="],
+    "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
 
     "pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
@@ -1284,6 +1281,8 @@
     "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "tsup/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "viem/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "wait-port/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1371,8 +1370,6 @@
 
     "ora/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "permissionless/viem/ox": ["ox@0.11.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A=="],
-
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "1.0.3" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "spawndamnit/cross-spawn/path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1452,8 +1449,6 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
     "ora/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "permissionless/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "spawndamnit/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 


### PR DESCRIPTION
## Summary

Code changes that replace the use of `@sunodo/wagmi-plugin-hardhat-deploy` + `@cartesi/devnet` package in favour of `@cartesi/wagmi-plugin` from `rollups-ts` repository.

```ts
export default defineConfig({
    out: "src/contracts.ts",
    plugins: [rollupsContracts()],
});
```

`apps/cli` no longer depends on `@cartesi/devnet` at all.

## Changes

| file | change |
|---|---|
| `apps/cli/wagmi.config.ts` | `hardhatDeploy({ directory: … })` → `rollupsContracts()`; `rollupsPrtContracts()` left commented out |
| `apps/cli/package.json` | drop `@cartesi/devnet` and `@sunodo/wagmi-plugin-hardhat-deploy`, add `@cartesi/wagmi-plugin@1.0.0-alpha.6` |
| `apps/cli/src/base.ts` | surface three contracts the new codegen provides in `cartesi address-book` |

`@cartesi/wagmi-plugin` is pinned exactly, as `@cartesi/devnet` was — the plugin version determines codegen output. `1.0.0-alpha.6` is the newest published version.

## What the generated file looks like now

`rollupsContracts()` with no options defaults to **rollups-contracts v3.0.0-alpha.10**, and reads the release's anvil tarball too, so chain 31337 is covered out of the box.

## Address book additions

Three contracts the release now provides are added to `cartesi address-book`:

| entry | where | notes |
|---|---|---|
| `TestUsdc` | devnet only | a devnet test token new in alpha.9, alongside the existing `TestToken` / `TestNFT` / `TestMultiToken` |
| `RefundOutputBuilder` | devnet and live chains | new in rollups-contracts between alpha.6 and alpha.9, so `@cartesi/devnet` never had it |
| `UsdWithdrawalOutputBuilderFactory` | devnet and live chains | already generated before, just never surfaced in the address book — it is the factory behind the existing `TestUsdWithdrawalOutputBuilder` entry |

Only five contracts in alpha.9 are genuinely devnet-only — `TestFungibleToken`, `TestMultiToken`, `TestNonFungibleToken`, `TestUsdc` and `TestUsdWithdrawalOutputBuilder`. The other two above are deployed at the same address on all nine chains, which is why they go in `commonContracts`.

This changes `cartesi address-book` output: 14 devnet rows become 17, and the fork output gains 2.

## Merge blockers

### 1. Version alignment with the SDK image

The devnet Anvil state the CLI actually talks to is baked into the SDK image, and it is built from **dave v3.0.0-alpha.3**, i.e. rollups-contracts **v3.0.0-alpha.6**. Codegen now emits **v3.0.0-alpha.10** addresses. Until the image catches up, `cartesi run` on devnet would talk to addresses that hold no code.

**[#515](https://github.com/cartesi/cli/pull/515)** is the other half: it moves the SDK image off `@cartesi/devnet` too, pulling `anvil_state.json` straight from the dave release (`CARTESI_PRT_VERSION = 3.0.0-alpha.4`, `FOUNDRY_VERSION = 1.5.1`), and it stops shipping `/usr/share/cartesi/deployments` and printing the address list from the `devnet` script — *"use `cartesi address-book`"*. It depends on dave **v3.0.0-alpha.4**.

So this PR and #515 must land together, with `DEFAULT_SDK_VERSION` in `src/config.ts:93` bumped to the resulting image, and the generated 31337 addresses re-checked against `deployments/31337/` in the dave anvil tarball that image loads. That check also confirms dave alpha.4 is built against rollups-contracts alpha.9 rather than an earlier release — the matching anvil version (1.5.1 in both) is suggestive but not proof.

Worth knowing: after #515, this generated file is the **only** place devnet addresses are printed, so a codegen mistake is no longer cross-checkable at runtime.

## Checklist before merge

- [ ] dave releases v3.0.0-alpha.4, [#515](https://github.com/cartesi/cli/pull/515) merges, and an SDK image ships
- [ ] Bump `DEFAULT_SDK_VERSION` in `apps/cli/src/config.ts` to that image
- [ ] Confirm dave v3.0.0-alpha.4 is built against rollups-contracts v3.0.0-alpha.10, and that the generated 31337 addresses match `deployments/31337/` in its anvil tarball
- [ ] `bun run --cwd apps/cli codegen && bun run --cwd apps/cli compile` clean
- [ ] `bun test apps/cli/` green — the expected addresses in `tests/unit/validations.test.ts` and `tests/unit/compose/node.test.ts` need updating for alpha.10
- [ ] `bun lint` clean
- [ ] Smoke test against the new SDK image: `cartesi run`, `cartesi address-book` (devnet **and** `--fork` on a public chain, checking the three new entries resolve), `cartesi run --prt`, `cartesi deposit erc20` against `TestFungibleToken`

## Follow-up (separate PR)

Once this and #515 are both in, nothing consumes `packages/devnet` any more. It can be deleted outright, along with `.github/workflows/devnet.yaml`, its workspace entry, and its row in `CLAUDE.md`. That is the endpoint this branch is named for.

## Notes for reviewers

- **Codegen now needs network access.** The plugin downloads and hash-verifies three tarballs (artifacts, deployment addresses, anvil) on every run and keeps nothing between runs, by design. Offline builds of `apps/cli` will fail; CI is unaffected.
